### PR TITLE
Docs: Inline docker yaml files (revises #1058)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: 3.x
-      - run: pip install mkdocs-material
+      - run: pip install mkdocs-material mkdocs-include-markdown-plugin
       - run: mkdocs gh-deploy --force

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -59,6 +59,8 @@ folder of the GitHub repository.
 
 In order to contribute to the documentation you can fork the repository and edit the markdown files in the browser.
 
+Now install mkdocs and dependencies: `pip install mkdocs-material mkdocs-include-markdown-plugin`.
+
 If you want to test the documentation locally run `mkdocs serve` from the project root.
 
 ## Contribute Translations

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -65,47 +65,11 @@ This configuration exposes the application through an nginx web server on port 8
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/plain/docker-compose.yml
 ```
 
-```yaml
-version: "3"
-services:
-  db_recipes:
-    restart: always
-    image: postgres:11-alpine
-    volumes:
-      - ./postgresql:/var/lib/postgresql/data
-    env_file:
-      - ./.env
-
-  web_recipes:
-    image: vabene1111/recipes
-    restart: always
-    env_file:
-      - ./.env
-    volumes:
-      - staticfiles:/opt/recipes/staticfiles
-      - nginx_config:/opt/recipes/nginx/conf.d
-      - ./mediafiles:/opt/recipes/mediafiles
-    depends_on:
-      - db_recipes
-
-  nginx_recipes:
-    image: nginx:mainline-alpine
-    restart: always
-    ports:
-      - 80:80
-    env_file:
-      - ./.env
-    depends_on:
-      - web_recipes
-    volumes:
-      - nginx_config:/etc/nginx/conf.d:ro
-      - staticfiles:/static
-      - ./mediafiles:/media
-
-volumes:
-  nginx_config:
-  staticfiles:
-```
+{%
+  include "./docker/plain/docker-compose.yml"
+  start="```yaml"
+  end="```\n"
+%}
 
 ### Reverse Proxy
 
@@ -123,62 +87,11 @@ If you use traefik, this configuration is the one for you.
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/traefik-nginx/docker-compose.yml
 ```
 
-```yaml
-version: "3"
-services:
-  db_recipes:
-    restart: always
-    image: postgres:11-alpine
-    volumes:
-      - ./postgresql:/var/lib/postgresql/data
-    env_file:
-      - ./.env
-    networks:
-      - default
-
-  web_recipes:
-    image: vabene1111/recipes
-    restart: always
-    env_file:
-      - ./.env
-    volumes:
-      - staticfiles:/opt/recipes/staticfiles
-      - nginx_config:/opt/recipes/nginx/conf.d
-      - ./mediafiles:/opt/recipes/mediafiles
-    depends_on:
-      - db_recipes
-    networks:
-      - default
-
-  nginx_recipes:
-    image: nginx:mainline-alpine
-    restart: always
-    env_file:
-      - ./.env
-    volumes:
-      - nginx_config:/etc/nginx/conf.d:ro
-      - staticfiles:/static
-      - ./mediafiles:/media
-    labels: # traefik example labels
-      - "traefik.enable=true"
-      - "traefik.http.routers.recipes.rule=Host(`recipes.mydomain.com`, `recipes.myotherdomain.com`)"
-      - "traefik.http.routers.recipes.entrypoints=web_secure" # your https endpoint
-      - "traefik.http.routers.recipes.tls.certresolver=le_resolver" # your cert resolver
-    depends_on:
-      - web_recipes
-    networks:
-      - default
-      - traefik
-
-networks:
-  default:
-  traefik: # This is you external traefik network
-    external: true
-
-volumes:
-  nginx_config:
-  staticfiles:
-```
+{%
+  include "./docker/traefik-nginx/docker-compose.yml"
+  start="```yaml"
+  end="```\n"
+%}
 
 #### nginx-proxy
 
@@ -198,58 +111,11 @@ LETSENCRYPT_EMAIL=
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/nginx-proxy/docker-compose.yml
 ```
 
-```yaml
-version: "3"
-services:
-  db_recipes:
-    restart: always
-    image: postgres:11-alpine
-    volumes:
-      - ./postgresql:/var/lib/postgresql/data
-    env_file:
-      - ./.env
-    networks:
-      - default
-
-  web_recipes:
-    image: vabene1111/recipes
-    restart: always
-    env_file:
-      - ./.env
-    volumes:
-      - staticfiles:/opt/recipes/staticfiles
-      - nginx_config:/opt/recipes/nginx/conf.d
-      - ./mediafiles:/opt/recipes/mediafiles
-    depends_on:
-      - db_recipes
-    networks:
-      - default
-
-  nginx_recipes:
-    image: nginx:mainline-alpine
-    restart: always
-    env_file:
-      - ./.env
-    depends_on:
-      - web_recipes
-    volumes:
-      - nginx_config:/etc/nginx/conf.d:ro
-      - staticfiles:/static
-      - ./mediafiles:/media
-    networks:
-      - default
-      - nginx-proxy
-
-networks:
-  default:
-  nginx-proxy:
-    external:
-      name: nginx-proxy
-
-volumes:
-  nginx_config:
-  staticfiles:
-```
+{%
+  include "./docker/nginx-proxy/docker-compose.yml"
+  start="```yaml"
+  end="```\n"
+%}
 
 ## Additional Information
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -65,11 +65,9 @@ This configuration exposes the application through an nginx web server on port 8
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/plain/docker-compose.yml
 ```
 
-{%
-  include "./docker/plain/docker-compose.yml"
-  start="```yaml"
-  end="```\n"
-%}
+~~~yaml
+{% include "./docker/plain/docker-compose.yml" %}
+~~~
 
 ### Reverse Proxy
 
@@ -87,11 +85,9 @@ If you use traefik, this configuration is the one for you.
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/traefik-nginx/docker-compose.yml
 ```
 
-{%
-  include "./docker/traefik-nginx/docker-compose.yml"
-  start="```yaml"
-  end="```\n"
-%}
+~~~yaml
+{% include "./docker/traefik-nginx/docker-compose.yml" %}
+~~~
 
 #### nginx-proxy
 
@@ -111,11 +107,9 @@ LETSENCRYPT_EMAIL=
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/nginx-proxy/docker-compose.yml
 ```
 
-{%
-  include "./docker/nginx-proxy/docker-compose.yml"
-  start="```yaml"
-  end="```\n"
-%}
+~~~yaml
+{% include "./docker/nginx-proxy/docker-compose.yml" %}
+~~~
 
 ## Additional Information
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,9 @@ markdown_extensions:
   - pymdownx.highlight
   - pymdownx.superfences
 
+plugins:
+  - include-markdown
+
 nav:
   - Home: 'index.md'
   - Installation:


### PR DESCRIPTION
This PR revises previous defunc #1058.

The inproper PR occured because testing was locally done with `mkdocs serve`. At this point I did not realize that `docs/index.md` contained absolute URLs to the install section of the documentation, hence linking to `https://docs.tandoor.dev/install/docker/` - and not the locally built section of the documentation.
As a result the respective documentation looked correct - when it actually was not!

## The actual fix

Using encapsulation of included file contents via

```
~~~yaml
{% include "./relative/docker-compose.yml" %}
~~~
```

This PR is now tested in a live environment: [Check it here](https://tuxuser.github.io/recipes/install/docker/)