### PR TITLE
Add ipv6 suppport to gunicorn

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -9,4 +9,4 @@ echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 
-exec gunicorn -b :8080 --access-logfile - --error-logfile - --log-level INFO recipes.wsgi
+exec gunicorn -b :8080 -b [::]:8080 --access-logfile - --error-logfile - --log-level INFO recipes.wsgi

--- a/boot.sh
+++ b/boot.sh
@@ -9,4 +9,4 @@ echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 
-exec gunicorn -b :8080 -b [::]:8080 --access-logfile - --error-logfile - --log-level INFO recipes.wsgi
+exec gunicorn -b [::]:8080 --access-logfile - --error-logfile - --log-level INFO recipes.wsgi


### PR DESCRIPTION
As per https://docs.gunicorn.org/en/stable/settings.html ("will bind the test:app application on localhost both on ipv6 and ipv4 interfaces.") multiple bind addresses are supported. This should add support for ipv6 docker networks.