### PR TITLE
Extension and hopefully simplification of bug reporting process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,9 +7,75 @@ assignees: ''
 
 ---
 
-### Version
-Please provide your current version (can be found on the system page since v0.8.4)
-Version: 
+## Version
+<!-- Please provide your current version (can be found on the system page since v0.8.4). -->
+**Tandoor-Version:** 
 
-### Bug description
+## Setup configuration
+<!--Please tick all boxes which apply to your configuration. Feel free to provide additional information below.  
+To tick boxes here, simply put an X inside the brackets below -->
+
+### Setup
+- [ ] Docker / Docker-Compose
+- [ ] Unraid
+- [ ] Synology
+- [ ] Kubernetes
+- [ ] Manual setup
+- [ ] Others (please state below)
+
+### Reverse Proxy
+- [ ] No reverse proxy
+- [ ] jwilder's nginx proxy
+- [ ] Nginx proxy manager (NPM)
+- [ ] SWAG
+- [ ] Caddy
+- [ ] Traefik
+- [ ] Others (please state below)
+
+<!-- Please provide additional information if possible -->
+**Additional information:** 
+
+## Bug description
 A clear and concise description of what the bug is.
+
+
+
+## Logs
+<!-- *(Remove this section entirely if no logs are available or necessary for your issue)*  
+To get the most information about your issue, set DEBUG=1 (e.g. in your `.env` file if using docker-compose) and try to reproduce the issue afterwards.
+
+Please put your logs into the expandable section below and use code quotation for all logs! Usage: Put three backticks in front and after the log, like this:  
+` ``` <Many lines of log messages ``` ` 
+
+Feel free to remove parts if you don't fill them out.
+-->
+
+<details>
+  <summary>Web-Container-Logs</summary>
+    
+  <!-- *Put your logs inside here (leave the code quotations in takt):* -->
+  
+  ```
+  Replace me with logs
+  ```
+</details>
+
+<details>
+  <summary>DB-Container-Logs</summary>
+    
+  <!-- *Put your logs inside here (leave the code quotations in takt):* -->
+  
+  ```
+  Replace me with logs
+  ```
+</details>
+
+<details>
+  <summary>Nginx-Container-Logs <!-- if you use one --></summary>
+    
+  <!-- *Put your logs inside here (leave the code quotations in takt):* -->
+  
+  ```
+  Replace me with logs
+  ```
+</details>


### PR DESCRIPTION
To get more information about bugs and prohibit having to ask one by one for specific information, I extended and redesigned the bug template.
Fell free to change parts or suggest changes.
Please note, that all explanatory parts are hidden as comments in the markdown (which the user will see when creating a bug ticket) so they don't unnecessarily clutter the finished bug report.