### PR TITLE
 #476 Import recipes with multiple instruction steps (for a custom Co…

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -149,3 +149,7 @@ REVERSE_PROXY_AUTH=0
 # Enables exporting PDF (see export docs)
 # Disabled by default, uncomment to enable
 # ENABLE_PDF_EXPORT=1
+
+# Enable experimental import of receipt steps
+# Disabled by default, uncomment to enable
+# ENABLE_IMPORT_STEPS=1

--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -7,7 +7,6 @@ from isodate import parse_duration as iso_parse_duration
 from isodate.isoerror import ISO8601Error
 from recipe_scrapers._utils import get_minutes
 
-from cookbook.helper import recipe_url_import as helper
 from cookbook.helper.ingredient_parser import IngredientParser
 from cookbook.models import Keyword
 
@@ -141,7 +140,8 @@ def get_from_scraper(scrape, request):
 
     try:
         recipe_json['recipeInstructions'] = parse_instructions(scrape.instructions())
-    except Exception:
+    except Exception as e:
+        print("Exception in parse_instructions(scrape.instructions())", e)
         recipe_json['recipeInstructions'] = ""
 
     if scrape.url:

--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -3,6 +3,7 @@ import re
 from html import unescape
 
 from django.utils.dateparse import parse_duration
+from django.utils.translation import gettext as _
 from isodate import parse_duration as iso_parse_duration
 from isodate.isoerror import ISO8601Error
 from recipe_scrapers._utils import get_minutes
@@ -146,7 +147,7 @@ def get_from_scraper(scrape, request):
 
     if scrape.url:
         recipe_json['url'] = scrape.url
-        recipe_json['recipeInstructions'] += "\n\nImported from " + scrape.url
+        recipe_json['recipeInstructions'] += "\n\n" + _("Imported from") + " " + scrape.url
     return recipe_json
 
 

--- a/cookbook/helper/scrapers/cookidoo.py
+++ b/cookbook/helper/scrapers/cookidoo.py
@@ -30,9 +30,12 @@ class Cookidoo(AbstractScraper):
                 )
 
             # add "header 1" markdown to marks the beginning of a new step
-            return "\n\n#STEP\n\n".join(
-                self.normalize_instruction(instruction) for instruction in instructions_gist
-            )
+            step_format = "\n\n" + _("#Step {}") + "\n\n{}"
+            return "".join(step_format.format(n, self.normalize_instruction(instruction))
+                           for n, instruction in enumerate(instructions_gist, start=1))
+            #return "\n\n#STEP\n\n".join(
+            #    self.normalize_instruction(instruction) for instruction in instructions_gist
+            #)
 
         return instructions
 

--- a/cookbook/helper/scrapers/cookidoo.py
+++ b/cookbook/helper/scrapers/cookidoo.py
@@ -1,0 +1,40 @@
+
+from recipe_scrapers._abstract import AbstractScraper
+from gettext import gettext as _
+
+
+class Cookidoo(AbstractScraper):
+    @classmethod
+    def host(cls, site='cookidoo'):
+        return {
+            'cookidoo': f"{site}.de",
+            #'cookidoo.at': f"{site}.at",
+            #'cookidoo.ch': f"{site}.ch",
+        }.get(site)
+
+    def normalize_instruction(self, instruction):
+        return instruction \
+            .replace("<nobr>", "**")\
+            .replace("</nobr>", "**")\
+            .replace("", _('Linkslauf'))\
+            .replace("", _('Kochlöffel'))
+
+    def instructions(self):
+        instructions = self.schema.data.get("recipeInstructions") or ""
+
+        if isinstance(instructions, list):
+            instructions_gist = []
+            for schema_instruction_item in instructions:
+                instructions_gist += self.schema._extract_howto_instructions_text(
+                    schema_instruction_item
+                )
+
+            # add "header 1" markdown to marks the beginning of a new step
+            return "\n\n#STEP\n\n".join(
+                self.normalize_instruction(instruction) for instruction in instructions_gist
+            )
+
+        return instructions
+
+    def ingredients(self):
+        return self.schema.ingredients()

--- a/cookbook/helper/scrapers/scrapers.py
+++ b/cookbook/helper/scrapers/scrapers.py
@@ -5,11 +5,13 @@ from recipe_scrapers._factory import SchemaScraperFactory
 from recipe_scrapers._schemaorg import SchemaOrg
 
 from .cooksillustrated import CooksIllustrated
+from .cookidoo import Cookidoo
 
 CUSTOM_SCRAPERS = {
     CooksIllustrated.host(site="cooksillustrated"): CooksIllustrated,
     CooksIllustrated.host(site="americastestkitchen"): CooksIllustrated,
     CooksIllustrated.host(site="cookscountry"): CooksIllustrated,
+    Cookidoo.host(site="cookidoo"): Cookidoo,
 }
 SCRAPERS.update(CUSTOM_SCRAPERS)
 

--- a/cookbook/locale/ca/LC_MESSAGES/django.po
+++ b/cookbook/locale/ca/LC_MESSAGES/django.po
@@ -31,6 +31,10 @@ msgstr ""
 msgid "Ingredients"
 msgstr "Ingredients"
 
+#: .\cookbook\helper\scrapers\recipe_url_import.py:150
+msgid "Imported from"
+msgstr "Imported from"
+
 #: .\cookbook\forms.py:54
 #, fuzzy
 #| msgid "Default"

--- a/cookbook/locale/ca/LC_MESSAGES/django.po
+++ b/cookbook/locale/ca/LC_MESSAGES/django.po
@@ -2348,9 +2348,14 @@ msgstr ""
 msgid "Instructions"
 msgstr "Instruccions"
 
-#: .\cookbook\templates\url_import.html:306
+#: .\cookbook\templates\url_import.html:308
 msgid ""
 "Recipe instructions dragged here will be appended to current instructions."
+msgstr ""
+
+#: .\cookbook\templates\url_import.html:309
+msgid ""
+"The markdown # for a header marks a new step."
 msgstr ""
 
 #: .\cookbook\templates\url_import.html:329
@@ -2813,6 +2818,18 @@ msgid ""
 "Recipe sharing link has been disabled! For additional information please "
 "contact the page administrator."
 msgstr ""
+
+#: .\cookbook\helper\scrapers\cookidoo.py:19
+msgid "Linkslauf"
+msgstr "Reverse"
+
+#: .\cookbook\helper\scrapers\cookidoo.py:20
+msgid "Kochlöffel"
+msgstr "spoon"
+
+#: .\cookbook\helper\scrapers\cookidoo.py:33
+msgid "#Step {}"
+msgstr "#Step {}"
 
 #~ msgid "New Unit"
 #~ msgstr "Nova Unitat"

--- a/cookbook/locale/de/LC_MESSAGES/django.po
+++ b/cookbook/locale/de/LC_MESSAGES/django.po
@@ -3234,5 +3234,11 @@ msgstr ""
 #~ msgid "Linkslauf"
 #~ msgstr "Linkslauf"
 
-#~ msgid "Kochlöffel"
-#~ msgstr "Kochlöffel"
+msgid "Kochlöffel"
+msgstr "Kochlöffel"
+
+msgid "Linkslauf"
+msgstr "Linkslauf"
+
+msgid "#Step {}"
+msgstr "#Schritt {}"

--- a/cookbook/locale/de/LC_MESSAGES/django.po
+++ b/cookbook/locale/de/LC_MESSAGES/django.po
@@ -3242,3 +3242,6 @@ msgstr "Linkslauf"
 
 msgid "#Step {}"
 msgstr "#Schritt {}"
+
+msgid "Imported from"
+msgstr "Importiert aus"

--- a/cookbook/locale/de/LC_MESSAGES/django.po
+++ b/cookbook/locale/de/LC_MESSAGES/django.po
@@ -3230,3 +3230,9 @@ msgstr ""
 
 #~ msgid "This recipe is already linked to the book!"
 #~ msgstr "Dieses Rezept ist bereits mit dem Buch verlinkt!"
+
+#~ msgid "Linkslauf"
+#~ msgstr "Linkslauf"
+
+#~ msgid "Kochlöffel"
+#~ msgstr "Kochlöffel"

--- a/cookbook/templates/url_import.html
+++ b/cookbook/templates/url_import.html
@@ -306,11 +306,12 @@
                                            title="{% trans 'Clear Contents' %}"></i>
                                     </div>
                                     <div class="small text-muted">{% trans 'Recipe instructions dragged here will be appended to current instructions.' %}</div>
+                                    <div class="small text-muted">{% trans 'The markdown # for a header marks a new step.' %}</div>
                                 </div>
                                 <b-collapse id="collapse-instructions" visible class="mt-2">
                                     <div class="card-body drop-zone" @drop="replacePreview('instructions', $event)"
                                          @dragover.prevent @dragenter.prevent>
-                                        <div class="card-text">[[recipe_json.recipeInstructions]]</div>
+                                        <div class="card-text"><pre>[[recipe_json.recipeInstructions]]</pre></div>
                                     </div>
                                 </b-collapse>
                             </div>
@@ -572,6 +573,7 @@
 
                 <div class="form-group">
                     <label for="id_instructions">{% trans 'Instructions' %}</label>
+                    <div class="small text-muted">{% trans 'The markdown # for a header marks a new step.' %}</div>
                     <textarea id="id_instructions" class="form-control" v-model="recipe_data.recipeInstructions"
                               rows="8"></textarea>
                 </div>

--- a/cookbook/views/data.py
+++ b/cookbook/views/data.py
@@ -155,10 +155,12 @@ def import_url(request):
         steps = []
         next_step_name = ""
         for instruction in instructions:
+            if not instruction.strip():
+                continue
             if instruction.startswith('#'):
                 next_step_name = instruction[1:]
             else:
-                new_step = Step.objects.create(name=next_step_name, instruction=instruction, space=request.space)
+                new_step = Step.objects.create(name=next_step_name.strip(), instruction=instruction.strip(), space=request.space)
                 next_step_name = ""
                 steps.append(new_step)
                 new_step.save()

--- a/cookbook/views/data.py
+++ b/cookbook/views/data.py
@@ -167,12 +167,15 @@ def import_url(request):
                 recipe.steps.add(new_step)
 
         for kw in data['keywords']:
+            if not kw['text'].strip():
+                # ignore blank keywords
+                continue
             if data['all_keywords']: # do not remove this check :) https://github.com/vabene1111/recipes/issues/645
-                k, created = Keyword.objects.get_or_create(name=kw['text'], space=request.space)
+                k, created = Keyword.objects.get_or_create(name=kw['text'].strip(), space=request.space)
                 recipe.keywords.add(k)
             else:
                 try:
-                    k = Keyword.objects.get(name=kw['text'], space=request.space)
+                    k = Keyword.objects.get(name=kw['text'].strip(), space=request.space)
                     recipe.keywords.add(k)
                 except ObjectDoesNotExist:
                     pass

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -139,6 +139,8 @@ ENABLE_METRICS = bool(int(os.getenv('ENABLE_METRICS', False)))
 
 ENABLE_PDF_EXPORT = bool(int(os.getenv('ENABLE_PDF_EXPORT', False)))
 
+ENABLE_IMPORT_STEPS = bool(int(os.getenv('ENABLE_IMPORT_STEPS', False)))
+
 MIDDLEWARE = [
     'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',


### PR DESCRIPTION
- Implement a custom scraper for Cookidoo with handling of stite specific formatings
- Implement the ability to manually or automatically import multi-step receipts by using the "Header 1" markdown
- automatically assign ingredients to the first step that mentions them when importing a multi step receipt