### PR TITLE
Example for third-party authentication

### DIFF
--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -32,7 +32,7 @@ as environment files loaded by docker compose don't support multiple lines for a
 
 Take the example configuration from the allauth docs, fill in your settings and then inline the whole object 
 (you can use a service like [www.freeformatter.com](https://www.freeformatter.com/json-formatter.html) for formatting).
-Assign it to the `SOCIALACCOUNT_PROVIDERS` variable.
+Assign it to the additional `SOCIALACCOUNT_PROVIDERS` variable.
 
 ```ini
 SOCIALACCOUNT_PROVIDERS={"nextcloud":{"SERVER":"https://nextcloud.example.org"}}
@@ -55,6 +55,25 @@ Use the superuser account to grant permissions to the newly created users.
 !!! info "WIP"
     I do not have a ton of experience with using various single signon providers and also cannot test all of them.
     If you have any Feedback or issues let me know.
+
+### Third-party authentication example
+Keycloak is a popular IAM solution and integration is straight forward thanks to Django Allauth. This example can also be used as reference for other third-party authentication solutions, as documented by Allauth.
+
+At Keycloak, create a new client and assign a `Client-ID`, this client comes with a `Secret-Key`. Both values are required later on. Make sure to define the correct Redirection-URL for the service, for example `https://tandoor.example.com/*`. Depending on your Keycloak setup, you need to assign roles and groups to grant access to the service.
+
+To enable Keycloak as a sign in option, set those variables to define the social provider and specify its configuration:
+```ini
+SOCIAL_PROVIDERS=allauth.socialaccount.providers.keycloak
+SOCIALACCOUNT_PROVIDERS='{ "keycloak": { "KEYCLOAK_URL": "https://auth.example.com/", "KEYCLOAK_REALM": "master" } }'
+```
+
+1. Restart the service, login as superuser and open the `Admin` page.
+2. Make sure that the correct `Domain Name` is defined at `Sites`.
+3. Select `Social Application` and chose `Keycloak` from the provider list.
+4. Provide an arbitrary name for your authentication provider, and enter the `Client-ID` and `Secret Key` values obtained from Keycloak earlier.
+5. Make sure to add your `Site` to the list of available sites and save the new `Social Application`.
+
+You are now able to sign in using Keycloak.
 
 ### Linking accounts
 To link an account to an already existing normal user go to the settings page of the user and link it. 


### PR DESCRIPTION
Providing an example to integrate Keycloak as IAM for Tandoor. Hinting that both SOCIAL* variables are required.