### PR TITLE
Allow to specify an actual path using DATABASE_URL

### DIFF
--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -258,7 +258,7 @@ WSGI_APPLICATION = 'recipes.wsgi.application'
 # Load settings from env files
 if os.getenv('DATABASE_URL'):
     match = re.match(
-        r'(?P<schema>\w+):\/\/(?P<user>[\w\d_-]+)(:(?P<password>[^@]+))?@(?P<host>[^:/]+)(:(?P<port>\d+))?(\/(?P<database>[\w\d_-]+))?',
+        r'(?P<schema>\w+):\/\/(?P<user>[\w\d_-]+)(:(?P<password>[^@]+))?@(?P<host>[^:/]+)(:(?P<port>\d+))?(\/(?P<database>[\w\d\/\._-]+))?',
         os.getenv('DATABASE_URL')
     )
     settings = match.groupdict()


### PR DESCRIPTION
Currently there is no possibility to move the location of `db.sqlite3` out of `/opt/recipes`. This pull request allows to specify full paths via `DATABASE_URL`, e.g.:

```
sqlite://nobody@nowhere/db/db.sqlite3
```

This will not access `/opt/recipes/db.sqlite` but `/opt/recipes/db/db.sqlite`.
