### PR TITLE
Add hint about trailing slashes for subpath setups

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -45,7 +45,8 @@ SHOPPING_MIN_AUTOSYNC_INTERVAL=5
 # Default for user setting sticky navbar
 # STICKY_NAV_PREF_DEFAULT=1
 
-# If base URL is something other than just /  (you are serving a subfolder in your proxy for instance http://recipe_app/recipes/)
+# If base URL is something other than just / (you are serving a subfolder in your proxy for instance http://recipe_app/recipes/)
+# Be sure to not have a trailing slash: e.g. '/recipes' instead of '/recipes/'
 # SCRIPT_NAME=/recipes
 
 # If staticfiles are stored at a different location uncomment and change accordingly, MUST END IN /


### PR DESCRIPTION
Add hint about trailing slashes for subpath setups due to recent issue on Discord.