### PR TITLE
[Docs] Added example configs and header information

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -45,6 +45,10 @@ The other common issue is that the recommended nginx container is removed from t
 If removed, the nginx webserver needs to be replaced by something else that servers the /mediafiles/ directory or 
 `GUNICORN_MEDIA` needs to be enabled to allow media serving by the application container itself.
 
+## Why is Tandoor not working on my Raspberry Pi?
+
+Please refer to [here](install/docker.md#setup-issues-on-raspberry-pi).
+
 ## How can I create users?
 To create a new user click on your name (top right corner) and select system. There click on invite links and create a new invite link.
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -18,6 +18,17 @@ Open Tandoor, open the menu behind the three vertical dots at the top right, sel
 #### Microsoft Edge
 Open Tandoor, open the menu behind the three horizontal dots at the top right, select `Apps > Install Tandoor Recipes`
 
+## Why is Tandoor not working correctly?
+If you just set up your Tandoor instance and you're having issues like...
+
+- Links not working
+- CSRF errors
+- CORS errors
+- No recipes are loading
+
+... then make sure, that you have set [all required headers](install/docker.md#required-headers) in your reverse proxy correctly.
+If that doesn't fix it, you can also refer to the appropriate sub section in the [reverse proxy documentation](install/docker.md#reverse-proxy) and verify your general webserver configuration.
+
 ## Why am I getting CSRF Errors?
 If you are getting CSRF Errors this is most likely due to a reverse proxy not passing the correct headers.
 

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -341,12 +341,7 @@ If you're having issues with installing Tandoor on your Raspberry Pi or similar 
 follow these instructions:
 
 - Stop all Tandoor containers (`docker-compose down`)
-- Retry by starting everything again (`docker-compose up -d`) (yes, seriously; if the database starts too slow, the start of the web container will fail)
-
-If this doesn't work (and you waited at least 30-60 seconds after you started the containers), try this:
-
-- Stop all Tandoor containers (`docker-compose down`)
 - Delete local database folder (usually 'postgresql' in the same folder as your 'docker-compose.yml' file)
 - Start Tandoor containers again (`docker-compose up -d`)
-- Wait for at least 30-60 seconds and then check if everything is working now
+- Wait for at least 30-60 seconds and then check if everything is working now (migrations can take quite some time!)
 - If not, check logs of the web_recipes container with `docker logs <container_name>` and make sure that all migrations are indeed already done

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -102,7 +102,7 @@ wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/d
 !!!note
     Don't forget to [download and configure](#docker-compose) your ```.env``` file!
 
-#### **nginx-proxy**
+#### **jwilder's Nginx-proxy**
 
 This is a docker compose example using [jwilder's nginx reverse proxy](https://github.com/jwilder/docker-gen)
 in combination with [jrcs's letsencrypt companion](https://hub.docker.com/r/jrcs/letsencrypt-nginx-proxy-companion/).
@@ -151,6 +151,102 @@ In both cases, also make sure to mount `/media/` in your swag container to point
 Please refer to the [appropriate documentation](https://github.com/linuxserver/docker-swag#usage) for the container setup.
 
 For step-by-step instructions to set this up from scratch, see [this example](swag.md).
+
+#### **Pure Nginx**
+
+If you have Nginx installed locally on your host system without using any third party integration like Swag or similar, this is for you.
+
+You can use the Docker-Compose file from [Plain](#plain).
+!!!warning "Adjust Docker-Compose file"
+    Replace `80:80` with `PORT:80` with PORT being your desired outward-facing port.
+    In the nginx config example below, 8080 is used.
+
+An example configuration with LetsEncrypt to get you started can be seen below.
+Please note, that since every setup is different, you might need to adjust some things.
+
+!!!warning "Placeholders"
+    Don't forget to replace the domain and port.
+
+```nginx
+server {
+    if ($host = recipes.mydomain.tld) { # replace domain
+        return 301 https://$host$request_uri;
+    }
+
+    server_name recipes.mydomain.tld; # replace domain
+    listen 80;
+    return 404;
+}
+server {
+    server_name recipes.mydomain.tld; # replace domain
+    listen 443 ssl;
+
+    ssl_certificate /etc/letsencrypt/live/recipes.mydomain.tld/fullchain.pem; # replace domain
+    ssl_certificate_key /etc/letsencrypt/live/recipes.mydomain.tld/privkey.pem; # replace domain
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+        location / {
+            proxy_set_header Host $http_host; # try $host instead if this doesn't work
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_pass http://127.0.0.1:8080; # replace port
+            proxy_redirect http://127.0.0.1:8080 https://recipes.domain.tld; # replace port and domain
+        }
+}
+```
+
+!!!note
+    Don't forget to [download and configure](#docker-compose) your ```.env``` file!
+
+#### **Apache**
+
+You can use the Docker-Compose file from [Plain](#plain).
+!!!warning "Adjust Docker-Compose file"
+    Replace `80:80` with `PORT:80` with PORT being your desired outward-facing port.
+    In the Apache config example below, 8080 is used.
+
+If you use e.g. LetsEncrypt for SSL encryption, you can use the example configuration from [solaris7590](https://github.com/TandoorRecipes/recipes/issues/1312#issuecomment-1020034375) below.
+
+!!!warning "Placeholders"
+    Don't forget to replace the domain and port.
+
+```apache
+<IfModule mod_ssl.c>
+    <VirtualHost *:80>
+        ServerAdmin webmaster@mydomain.de # replace domain
+        ServerName mydomain.de # replace domain
+
+        Redirect permanent / https://mydomain.de/ # replace domain
+    </VirtualHost>
+
+    <VirtualHost *:443>
+        ServerAdmin webmaster@mydomain.de # replace domain
+        ServerName mydomain.de # replace domain
+
+        SSLEngine on
+
+        RequestHeader set X-Forwarded-Proto "https"
+        Header always set Access-Control-Allow-Origin "*"
+
+        ProxyPreserveHost  On
+        ProxyRequests Off
+        ProxyPass / http://localhost:8080/ # replace port
+        ProxyPassReverse / http://localhost:8080/ # replace port
+
+        SSLCertificateFile /etc/letsencrypt/live/mydomain.de/fullchain.pem # replace domain/path
+        SSLCertificateKeyFile /etc/letsencrypt/live/mydomain.de/privkey.pem # replace domain/path
+        Include /etc/letsencrypt/options-ssl-apache.conf
+
+        ErrorLog ${APACHE_LOG_DIR}/recipes_error.log
+        CustomLog ${APACHE_LOG_DIR}/recipes_access.log combined
+    </VirtualHost>
+</IfModule>
+```
+
+If you're having issues with the example configuration above, you can try [beedaddy](https://github.com/TandoorRecipes/recipes/issues/1312#issuecomment-1015252663)'s example config.
+
+!!!note
+    Don't forget to [download and configure](#docker-compose) your ```.env``` file!
 
 #### **Others**
 
@@ -213,3 +309,28 @@ configuration files for all user generated data (e.g. Postgresql and media files
 You can move everything to volumes if you prefer it this way, **but you cannot convert the nginx config file to a bind
 mount.**
 If you do so you will have to manually create the nginx config file and restart the container once after creating it.
+
+### **Required Headers**
+
+Please be sure to supply all required headers in your nginx/Apache/Caddy/... configuration!
+
+nginx:
+```nginx
+location / {
+    proxy_set_header Host $http_host; # try $host instead if this doesn't work
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_pass http://127.0.0.1:8080; # replace port
+    proxy_redirect http://127.0.0.1:8080 https://recipes.domain.tld; # replace port and domain
+}
+```
+
+Apache:
+```apache
+RequestHeader set X-Forwarded-Proto "https"
+Header always set Access-Control-Allow-Origin "*"
+
+ProxyPreserveHost  On
+ProxyRequests Off
+ProxyPass / http://localhost:8080/ # replace port
+ProxyPassReverse / http://localhost:8080/ # replace port
+```

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -337,11 +337,14 @@ ProxyPassReverse / http://localhost:8080/ # replace port
 
 ### **Setup issues on Raspberry Pi**
 
+!!!info
+    Always wait at least 2-3 minutes after the very first start, since migrations will take some time!
+
 If you're having issues with installing Tandoor on your Raspberry Pi or similar device,
 follow these instructions:
 
 - Stop all Tandoor containers (`docker-compose down`)
 - Delete local database folder (usually 'postgresql' in the same folder as your 'docker-compose.yml' file)
 - Start Tandoor containers again (`docker-compose up -d`)
-- Wait for at least 30-60 seconds and then check if everything is working now (migrations can take quite some time!)
+- Wait for at least 2-3 minutes and then check if everything is working now (migrations can take quite some time!)
 - If not, check logs of the web_recipes container with `docker logs <container_name>` and make sure that all migrations are indeed already done

--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -334,3 +334,19 @@ ProxyRequests Off
 ProxyPass / http://localhost:8080/ # replace port
 ProxyPassReverse / http://localhost:8080/ # replace port
 ```
+
+### **Setup issues on Raspberry Pi**
+
+If you're having issues with installing Tandoor on your Raspberry Pi or similar device,
+follow these instructions:
+
+- Stop all Tandoor containers (`docker-compose down`)
+- Retry by starting everything again (`docker-compose up -d`) (yes, seriously; if the database starts too slow, the start of the web container will fail)
+
+If this doesn't work (and you waited at least 30-60 seconds after you started the containers), try this:
+
+- Stop all Tandoor containers (`docker-compose down`)
+- Delete local database folder (usually 'postgresql' in the same folder as your 'docker-compose.yml' file)
+- Start Tandoor containers again (`docker-compose up -d`)
+- Wait for at least 30-60 seconds and then check if everything is working now
+- If not, check logs of the web_recipes container with `docker logs <container_name>` and make sure that all migrations are indeed already done


### PR DESCRIPTION
Added example configs for plain local nginx and Apache2.
Also added FAQ section for all generic issues when not setting all required headers correctly.
Added section for required headers in the Docker installation docs.

I hope this reduces the amount of "header-issues" which seem to be a constant issue-source.
As always, feel free to adjust.