### PR TITLE
[Docker] Web_recipes waits for db_recipes to be ready

### DIFF
--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - ./.env
     networks:
       - default
+    healthcheck:
+      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   web_recipes:
     image: vabene1111/recipes
@@ -20,7 +25,8 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      - db_recipes
+      db_recipes:
+        condition: service_healthy
     networks:
       - default
 

--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - default
     healthcheck:
       test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 5s
-      timeout: 2s
-      retries: 5
+      interval: 4s
+      timeout: 1s
+      retries: 12
 
   web_recipes:
     image: vabene1111/recipes

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -9,9 +9,9 @@ services:
       - ./.env
     healthcheck:
       test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 5s
-      timeout: 2s
-      retries: 5
+      interval: 4s
+      timeout: 1s
+      retries: 12
 
   web_recipes:
     image: vabene1111/recipes

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -7,6 +7,11 @@ services:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
       - ./.env
+    healthcheck:
+      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   web_recipes:
     image: vabene1111/recipes
@@ -18,7 +23,8 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      - db_recipes
+      db_recipes:
+        condition: service_healthy
 
   nginx_recipes:
     image: nginx:mainline-alpine

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -9,6 +9,11 @@ services:
       - ./.env
     networks:
       - default
+    healthcheck:
+      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
+      interval: 5s
+      timeout: 2s
+      retries: 5
 
   web_recipes:
     image: vabene1111/recipes
@@ -20,7 +25,8 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      - db_recipes
+      db_recipes:
+        condition: service_healthy
     networks:
       - default
 

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -11,9 +11,9 @@ services:
       - default
     healthcheck:
       test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 5s
-      timeout: 2s
-      retries: 5
+      interval: 4s
+      timeout: 1s
+      retries: 12
 
   web_recipes:
     image: vabene1111/recipes


### PR DESCRIPTION
Fixes the setup issue almost all Raspberry Pi users have and probably some others with slow or low spec systems.
The web_recipes container waits for db_recipes to be healthy.
db_recipes is healthy, as soon as postgres is completely ready.

Note: ps_isready doesn't work here for some reason.

Tested multiple times with a Raspberry Pi 4.