### PR TITLE
Simple font size change

### DIFF
--- a/vue/src/components/MealPlanCalenderHeader.vue
+++ b/vue/src/components/MealPlanCalenderHeader.vue
@@ -134,7 +134,7 @@ export default {
   flex-flow: row nowrap;
   min-height: 1.5em;
   line-height: 1;
-  font-size: 1.5em;
+  font-size: 1em;
 }
 
 .period-span-1 {


### PR DESCRIPTION
Made a small change to the font size so longer months won't affect arrow buttons. I think this helps the meal plan calendar look more aesthetic.
Here's an example: 
(before)
<img width="650" alt="before" src="https://user-images.githubusercontent.com/73865366/151685913-ec032029-974f-466c-9496-2292bd1601d9.png">
(after)
<img width="650" alt="after" src="https://user-images.githubusercontent.com/73865366/151685916-7f58907f-7661-4e2b-89ea-782cd497fe4b.png">

