### PR TITLE
Add new env parameter to set ldap ca cert file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -146,6 +146,7 @@ REVERSE_PROXY_AUTH=0
 #AUTH_LDAP_BIND_DN=
 #AUTH_LDAP_BIND_PASSWORD=
 #AUTH_LDAP_USER_SEARCH_BASE_DN=
+#AUTH_LDAP_TLS_CACERTFILE=
 
 # Enables exporting PDF (see export docs)
 # Disabled by default, uncomment to enable

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -96,6 +96,7 @@ AUTH_LDAP_USER_SEARCH_FILTER_STR=(uid=%(user)s)
 AUTH_LDAP_USER_ATTR_MAP={'first_name': 'givenName', 'last_name': 'sn', 'email': 'mail'}
 AUTH_LDAP_ALWAYS_UPDATE_USER=1
 AUTH_LDAP_CACHE_TIMEOUT=3600
+AUTH_LDAP_TLS_CACERTFILE=/etc/ssl/certs/own-ca.pem
 ```
 
 ## Reverse Proxy Authentication

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -186,6 +186,8 @@ if LDAP_AUTH:
     }
     AUTH_LDAP_ALWAYS_UPDATE_USER = bool(int(os.getenv('AUTH_LDAP_ALWAYS_UPDATE_USER', True)))
     AUTH_LDAP_CACHE_TIMEOUT = int(os.getenv('AUTH_LDAP_CACHE_TIMEOUT', 3600))
+    if 'AUTH_LDAP_TLS_CACERTFILE' in os.environ:
+        AUTH_LDAP_GLOBAL_OPTIONS = { ldap.OPT_X_TLS_CACERTFILE: os.getenv('AUTH_LDAP_TLS_CACERTFILE') }
 
 AUTHENTICATION_BACKENDS += [
     'django.contrib.auth.backends.ModelBackend',


### PR DESCRIPTION
My ldap server uses TLS encryption with self signed certificates. With this PR it's possible to set the ca cert file used in ldap authentication to check the ldap server certificate via an optional environment variable. Details can be found [here](https://www.python-ldap.org/en/python-ldap-3.3.0/reference/ldap.html#ldap.OPT_X_TLS_CACERTFILE).