### PR TITLE
K8s deployment: Small fix for dupplicate entries.

### DIFF
--- a/docs/install/k8s/40-sts-postgresql.yaml
+++ b/docs/install/k8s/40-sts-postgresql.yaml
@@ -24,12 +24,6 @@ spec:
       name: recipes-postgresql
       namespace: default
     spec:
-      restartPolicy: Always
-      securityContext:
-        fsGroup: 999
-      serviceAccount: recipes
-      serviceAccountName: recipes
-      terminationGracePeriodSeconds: 30
       containers:
       - name: recipes-db
         env:
@@ -125,8 +119,6 @@ spec:
       serviceAccount: recipes
       serviceAccountName: recipes
       terminationGracePeriodSeconds: 30
-  updateStrategy:
-    type: RollingUpdate
   volumeClaimTemplates:
   - apiVersion: v1
     kind: PersistentVolumeClaim


### PR DESCRIPTION
@TomHutter tagging you here, because you did the main work on this docs. 
Found some dupplicate declarations in the `40-sts-postgresql.yaml`, which should be fixed with this commit. 