### PR TITLE
Moved DB-waiting from docker-level to container-level

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -3,7 +3,7 @@ source venv/bin/activate
 
 echo "Updating database"
 while python manage.py migrate ; status=$? ; [ $status -eq 1 ]; do
-        echo "Migration failed! Database may not be ready yet, retrying in 5 seconds..."
+        echo "Migration failed (error #${status})! Database may not be ready yet, retrying in 5 seconds..."
         sleep 5
 done
 python manage.py collectstatic_js_reverse

--- a/boot.sh
+++ b/boot.sh
@@ -1,13 +1,33 @@
 #!/bin/sh
 source venv/bin/activate
 
-echo "Updating database"
-while python manage.py migrate ; status=$? ; [ $status -eq 1 ]; do
-        echo "Migration failed (error #${status})! Database may not be ready yet, retrying in 5 seconds..."
-        sleep 5
+echo "Migrating database"
+
+attempt=0
+max_attempts=20
+while python manage.py migrate; \
+      status=$?; \
+      attempt=$((attempt+1)); \
+      [ $status -eq 1 ] \
+   && [ $attempt -le $max_attempts ]; do
+    echo -e "\n!!! Migration failed (error ${status}, attempt ${attempt}/${max_attempts})."
+    echo "!!! Database may not be ready yet or system is misconfigured."
+    echo -e "!!! Retrying in 5 seconds...\n"
+    sleep 5
 done
+
+if [ $attempt -gt $max_attempts ]; then
+    echo -e "\n!!! Migration failed. Maximum attempts exceeded."
+    echo "!!! Please check logs above - misconfiguration is very likely."
+    echo "!!! Shutting down container."
+    exit 1 # exit with error to make the container stop
+fi
+
+echo "Generating static files"
+
 python manage.py collectstatic_js_reverse
 python manage.py collectstatic --noinput
+
 echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles

--- a/boot.sh
+++ b/boot.sh
@@ -2,7 +2,10 @@
 source venv/bin/activate
 
 echo "Updating database"
-python manage.py migrate
+while python manage.py migrate ; status=$? ; [ $status -eq 1 ]; do
+        echo "Migration failed due to database not being ready yet, retrying in 5 seconds..."
+        sleep 5
+done
 python manage.py collectstatic_js_reverse
 python manage.py collectstatic --noinput
 echo "Done"

--- a/boot.sh
+++ b/boot.sh
@@ -3,7 +3,7 @@ source venv/bin/activate
 
 echo "Updating database"
 while python manage.py migrate ; status=$? ; [ $status -eq 1 ]; do
-        echo "Migration failed due to database not being ready yet, retrying in 5 seconds..."
+        echo "Migration failed! Database may not be ready yet, retrying in 5 seconds..."
         sleep 5
 done
 python manage.py collectstatic_js_reverse

--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -9,11 +9,6 @@ services:
       - ./.env
     networks:
       - default
-    healthcheck:
-      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 4s
-      timeout: 1s
-      retries: 12
 
   web_recipes:
     image: vabene1111/recipes
@@ -25,8 +20,7 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      db_recipes:
-        condition: service_healthy
+      - db_recipes
     networks:
       - default
 

--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -12,7 +12,6 @@ services:
 
   web_recipes:
     image: vabene1111/recipes
-    restart: always
     env_file:
       - ./.env
     volumes:

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -10,7 +10,6 @@ services:
 
   web_recipes:
     image: vabene1111/recipes
-    restart: always
     env_file:
       - ./.env
     volumes:

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -7,11 +7,6 @@ services:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
       - ./.env
-    healthcheck:
-      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 4s
-      timeout: 1s
-      retries: 12
 
   web_recipes:
     image: vabene1111/recipes
@@ -23,8 +18,7 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      db_recipes:
-        condition: service_healthy
+      - db_recipes
 
   nginx_recipes:
     image: nginx:mainline-alpine

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -9,11 +9,6 @@ services:
       - ./.env
     networks:
       - default
-    healthcheck:
-      test: ["CMD-SHELL", "psql -U $$POSTGRES_USER -d $$POSTGRES_DB --list || exit 1"]
-      interval: 4s
-      timeout: 1s
-      retries: 12
 
   web_recipes:
     image: vabene1111/recipes
@@ -25,8 +20,7 @@ services:
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
-      db_recipes:
-        condition: service_healthy
+      - db_recipes
     networks:
       - default
 

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -12,7 +12,6 @@ services:
 
   web_recipes:
     image: vabene1111/recipes
-    restart: always
     env_file:
       - ./.env
     volumes:


### PR DESCRIPTION
Undid the depends_on change in the docker-compose file, since it requires a fairly recent docker-compose version (>= 1.27.0) and can therefore cause issues in some cases.

In general, this should be handled by the requester - so the web-container - anyway.

`boot.sh` now retries every 5 seconds when the `python manage.py migrate` command exits with error code `1`.
This error code is thrown, when the DB (container) is not reachable yet (the exact error we're trying to tackle here). Also, when there is a misconfiguration like renamed db-container, where retries won't help but it doesn't hurt either - still worth it imo since it's an easy fix in the boot.sh like this.
Other errors I could provoke exited with error 130 so not all exit with a 1.
Success is obviously 0.

Tested with a Raspberry Pi 4 and on an Ubuntu 20.04 cloud server with reverse proxy.