### PR TITLE
Ping DB instead of trying migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.9-alpine3.12
 
 #Install all dependencies.
-RUN apk add --no-cache postgresql-libs gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography
+RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography
 
 #Print all logs without buffering it.
 ENV PYTHONUNBUFFERED 1
@@ -15,7 +15,7 @@ WORKDIR /opt/recipes
 
 COPY requirements.txt ./
 
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev postgresql zlib-dev jpeg-dev libwebp-dev libressl-dev libffi-dev cargo openssl-dev openldap-dev && \
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev libressl-dev libffi-dev cargo openssl-dev openldap-dev && \
     python -m venv venv && \
     /opt/recipes/venv/bin/python -m pip install --upgrade pip && \
     venv/bin/pip install wheel==0.36.2 && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /opt/recipes
 
 COPY requirements.txt ./
 
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev libressl-dev libffi-dev cargo openssl-dev openldap-dev && \
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev postgresql zlib-dev jpeg-dev libwebp-dev libressl-dev libffi-dev cargo openssl-dev openldap-dev && \
     python -m venv venv && \
     /opt/recipes/venv/bin/python -m pip install --upgrade pip && \
     venv/bin/pip install wheel==0.36.2 && \

--- a/boot.sh
+++ b/boot.sh
@@ -1,27 +1,27 @@
 #!/bin/sh
 source venv/bin/activate
 
-echo "Migrating database"
+echo "Waiting for database to be ready..."
 
 attempt=0
 max_attempts=20
-while python manage.py migrate; \
-      status=$?; \
-      attempt=$((attempt+1)); \
-      [ $status -eq 1 ] \
-   && [ $attempt -le $max_attempts ]; do
-    echo -e "\n!!! Migration failed (error ${status}, attempt ${attempt}/${max_attempts})."
-    echo "!!! Database may not be ready yet or system is misconfigured."
-    echo -e "!!! Retrying in 5 seconds...\n"
-    sleep 5
+while pg_isready --host=${POSTGRES_HOST} -q; status=$?; attempt=$((attempt+1)); [ $status -ne 0 ] && [ $attempt -le $max_attempts ]; do
+    sleep 5 # no echo needed, response comes from pg_isready already
 done
 
 if [ $attempt -gt $max_attempts ]; then
-    echo -e "\n!!! Migration failed. Maximum attempts exceeded."
-    echo "!!! Please check logs above - misconfiguration is very likely."
-    echo "!!! Shutting down container."
+    echo -e "\nDatabase not reachable. Maximum attempts exceeded."
+    echo "Please check logs above - misconfiguration is very likely."
+	echo "Make sure the DB container is up and POSTGRES_HOST is set properly."
+    echo "Shutting down container."
     exit 1 # exit with error to make the container stop
 fi
+
+echo "Database is ready"
+
+echo "Migrating database"
+
+python manage.py migrate
 
 echo "Generating static files"
 


### PR DESCRIPTION
In #1498 I added a retry functionality for the migration.
Since blindly retrying migrations can be dangerous since I'd see it as blindly messing with data, knowing something isn't right, I decided to look for a better solution (and also reduce log spam drastically).

With this, the PostgreSQL server in POSTGRES_HOST (e.g. db_recipes) will be pinged before migration.

The only downside to this is the necessity to add postgresql as additional dependency which increases image size slightly.
If someone knows another way to get access to the pg_isready command, please let me know.