### PR TITLE
Added existence check for Nginx config file and mandatory parameters

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -6,7 +6,7 @@ NGINX_CONF_FILE=/opt/recipes/nginx/conf.d/Recipes.conf
 
 echo "Checking configuration..."
 
-if [ ! -f "$NGINX_CONF_FILE" ] && [ $GUNICORN_MEDIA -ne 1 ]; then
+if [ ! -f "$NGINX_CONF_FILE" ] && [ $GUNICORN_MEDIA -eq 0 ]; then
     echo -e "\n[WARNING]\nNginx configuration file could not be found at the default location!"
     echo -e "Path: ${NGINX_CONF_FILE}\n"
 fi

--- a/boot.sh
+++ b/boot.sh
@@ -6,7 +6,7 @@ NGINX_CONF_FILE=/opt/recipes/nginx/conf.d/Recipes.conf
 
 echo "Checking configuration..."
 
-if [ ! -f "$NGINX_CONF_FILE" ]; then
+if [ ! -f "$NGINX_CONF_FILE" ] && [ $GUNICORN_MEDIA -ne 1 ]; then
     echo -e "\n[WARNING]\nNginx configuration file could not be found at the default location!"
     echo -e "Path: ${NGINX_CONF_FILE}\n"
 fi

--- a/boot.sh
+++ b/boot.sh
@@ -4,11 +4,26 @@ source venv/bin/activate
 TANDOOR_PORT="${TANDOOR_PORT:-8080}"
 NGINX_CONF_FILE=/opt/recipes/nginx/conf.d/Recipes.conf
 
+display_warning() {
+    echo "[WARNING]"
+    echo -e "$1"
+}
+
 echo "Checking configuration..."
 
+# Nginx config file must exist if gunicorn is not active
 if [ ! -f "$NGINX_CONF_FILE" ] && [ $GUNICORN_MEDIA -eq 0 ]; then
-    echo -e "\n[WARNING]\nNginx configuration file could not be found at the default location!"
-    echo -e "Path: ${NGINX_CONF_FILE}\n"
+    display_warning "Nginx configuration file could not be found at the default location!\nPath: ${NGINX_CONF_FILE}"
+fi
+
+# SECRET_KEY must be set in .env file
+if [ -z "${SECRET_KEY}" ]; then
+    display_warning "The environment variable 'SECRET_KEY' is not set but REQUIRED for running Tandoor!"
+fi
+
+# POSTGRES_PASSWORD must be set in .env file
+if [ -z "${POSTGRES_PASSWORD}" ]; then
+    display_warning "The environment variable 'POSTGRES_PASSWORD' is not set but REQUIRED for running Tandoor!"
 fi
 
 echo "Waiting for database to be ready..."

--- a/boot.sh
+++ b/boot.sh
@@ -1,8 +1,15 @@
 #!/bin/sh
 source venv/bin/activate
 
-
 TANDOOR_PORT="${TANDOOR_PORT:-8080}"
+NGINX_CONF_FILE=/opt/recipes/nginx/conf.d/Recipes.conf
+
+echo "Checking configuration..."
+
+if [ ! -f "$NGINX_CONF_FILE" ]; then
+    echo -e "\n[WARNING]\nNginx configuration file could not be found at the default location!"
+    echo -e "Path: ${NGINX_CONF_FILE}\n"
+fi
 
 echo "Waiting for database to be ready..."
 


### PR DESCRIPTION
Checks on Web-Container startup, whether the Nginx configuration file (Recipes.conf) is present.
If it's not present - which would prohibit Nginx from working properly (see #1531) - a warning is shown.

If GUNICORN_MEDIA is not 0 (0 is default) and therefore Nginx is not used, no warning will be shown.

Path to config file is hardcoded, but there is no point in changing the mounting point in the docker-compose file anyway and the warning doesn't prohibit the startup - it's just to make issue analysis for the users and developers easier.