### PR TITLE
Added ldap as runtime dependency to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.10-alpine3.15
 
 #Install all dependencies.
-RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography
+RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography openldap
 
 #Print all logs without buffering it.
 ENV PYTHONUNBUFFERED 1


### PR DESCRIPTION
Fixes #1619

Added ldap as runtime dependency to Dockerfile since the new Alpine image seems to have removed that.

Thanks for the hint: https://github.com/TandoorRecipes/recipes/issues/1619#issuecomment-1058325544