### PR TITLE
Improve recipe import for non schema.org recipes

### DIFF
--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -28,9 +28,14 @@ def get_from_scraper(scrape, request):
             recipe_json['name'] = ''
 
     try:
-        description = scrape.schema.data.get("description") or ''
+        description = scrape.description()  or None
     except Exception:
-        description = ''
+        description = None
+    if not description:
+        try:
+            description = scrape.schema.data.get("description") or ''
+        except Exception:
+            description = ''
 
     recipe_json['description'] = parse_description(description)
 
@@ -51,13 +56,19 @@ def get_from_scraper(scrape, request):
     recipe_json['servings'] = max(servings, 1)
 
     try:
-        recipe_json['prepTime'] = get_minutes(scrape.schema.data.get("prepTime")) or 0
+        recipe_json['prepTime'] = get_minutes(scrape.prep_time()) or 0
     except Exception:
-        recipe_json['prepTime'] = 0
+        try:
+            recipe_json['prepTime'] = get_minutes(scrape.schema.data.get("prepTime")) or 0
+        except Exception:
+            recipe_json['prepTime'] = 0
     try:
-        recipe_json['cookTime'] = get_minutes(scrape.schema.data.get("cookTime")) or 0
+        recipe_json['cookTime'] = get_minutes(scrape.cook_time()) or 0
     except Exception:
-        recipe_json['cookTime'] = 0
+        try:
+            recipe_json['cookTime'] = get_minutes(scrape.schema.data.get("cookTime")) or 0
+        except Exception:
+            recipe_json['cookTime'] = 0
 
     if recipe_json['cookTime'] + recipe_json['prepTime'] == 0:
         try:
@@ -85,15 +96,23 @@ def get_from_scraper(scrape, request):
     except Exception:
         pass
     try:
-        if scrape.schema.data.get('recipeCategory'):
-            keywords += listify_keywords(scrape.schema.data.get("recipeCategory"))
+        if scrape.category():
+            keywords += listify_keywords(scrape.category())
     except Exception:
-        pass
+        try:
+            if scrape.schema.data.get('recipeCategory'):
+                keywords += listify_keywords(scrape.schema.data.get("recipeCategory"))
+        except Exception:
+            pass
     try:
-        if scrape.schema.data.get('recipeCuisine'):
-            keywords += listify_keywords(scrape.schema.data.get("recipeCuisine"))
+        if scrape.cuisine():
+            keywords += listify_keywords(scrape.cuisine())
     except Exception:
-        pass
+        try:
+            if scrape.schema.data.get('recipeCuisine'):
+                keywords += listify_keywords(scrape.schema.data.get("recipeCuisine"))
+        except Exception:
+            pass
     try:
         recipe_json['keywords'] = parse_keywords(list(set(map(str.casefold, keywords))), request.space)
     except AttributeError:
@@ -146,9 +165,9 @@ def get_from_scraper(scrape, request):
     except Exception:
         recipe_json['recipeInstructions'] = ""
 
-    if scrape.url:
-        recipe_json['url'] = scrape.url
-        recipe_json['recipeInstructions'] += "\n\n" + _("Imported from") + ": " + scrape.url
+    if scrape.canonical_url():
+        recipe_json['url'] = scrape.canonical_url()
+        recipe_json['recipeInstructions'] += "\n\n" + _("Imported from") + ": " + scrape.canonical_url()
     return recipe_json
 
 


### PR DESCRIPTION
When testing the import with version 13.19.0 of recipe-scraper, I realized that we do not use all information the scraper object may provide.

Especially when a recipe was scraped that didn't support Schema.org, scrape_me provides fields only through the respective scraper methods and not through its `schema.data` attribute.

Added support for
* `scrape.description()`
* `scrape.prep_time()`
* `scrape.cook_time()`
* Keywords from `scrape.cuisine()` and `scrape.category()`
If these properties return an exception the fallback is to use the old behaviour and try to get the data from the schema object directly.

getting the URL from `scrape.canonical_url()` instead of from `scrape.url` also can't screw anything up since in the recipe_scraper library the default implementation of `canonical_url` defaults to returning `scrape.url` anyway.