### PR TITLE
Fixed typos and grammatical issues.

### DIFF
--- a/cookbook/locale/ca/LC_MESSAGES/django.po
+++ b/cookbook/locale/ca/LC_MESSAGES/django.po
@@ -2991,7 +2991,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/de/LC_MESSAGES/django.po
+++ b/cookbook/locale/de/LC_MESSAGES/django.po
@@ -3107,7 +3107,7 @@ msgstr ""
 "paar Stunden."
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 "Email konnte an den Benutzer nicht gesendet werden. Bitte teile den Link "
 "manuell."

--- a/cookbook/locale/en/LC_MESSAGES/django.po
+++ b/cookbook/locale/en/LC_MESSAGES/django.po
@@ -2724,7 +2724,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/es/LC_MESSAGES/django.po
+++ b/cookbook/locale/es/LC_MESSAGES/django.po
@@ -3042,7 +3042,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/fi/LC_MESSAGES/django.po
+++ b/cookbook/locale/fi/LC_MESSAGES/django.po
@@ -2435,7 +2435,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:225
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:127

--- a/cookbook/locale/fr/LC_MESSAGES/django.po
+++ b/cookbook/locale/fr/LC_MESSAGES/django.po
@@ -3155,7 +3155,7 @@ msgstr ""
 "quelques heures."
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 "Impossible d’envoyer le mail à l’utilisateur, veuillez partager le lien "
 "manuellement."

--- a/cookbook/locale/hu_HU/LC_MESSAGES/django.po
+++ b/cookbook/locale/hu_HU/LC_MESSAGES/django.po
@@ -2776,7 +2776,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/it/LC_MESSAGES/django.po
+++ b/cookbook/locale/it/LC_MESSAGES/django.po
@@ -2952,7 +2952,7 @@ msgstr ""
 "ora."
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 "Non è stato possibile inviare l'email all'utente, condividi il link "
 "manualmente."

--- a/cookbook/locale/lv/LC_MESSAGES/django.po
+++ b/cookbook/locale/lv/LC_MESSAGES/django.po
@@ -2987,7 +2987,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/nl/LC_MESSAGES/django.po
+++ b/cookbook/locale/nl/LC_MESSAGES/django.po
@@ -3104,7 +3104,7 @@ msgstr ""
 "uren."
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 "E-mail aan gebruiker kon niet verzonden worden, deel de link handmatig."
 

--- a/cookbook/locale/pt/LC_MESSAGES/django.po
+++ b/cookbook/locale/pt/LC_MESSAGES/django.po
@@ -2888,7 +2888,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/pt_BR/LC_MESSAGES/django.po
+++ b/cookbook/locale/pt_BR/LC_MESSAGES/django.po
@@ -2729,7 +2729,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/rn/LC_MESSAGES/django.po
+++ b/cookbook/locale/rn/LC_MESSAGES/django.po
@@ -2724,7 +2724,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/ro/LC_MESSAGES/django.po
+++ b/cookbook/locale/ro/LC_MESSAGES/django.po
@@ -2493,7 +2493,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:229
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:127

--- a/cookbook/locale/ru/LC_MESSAGES/django.po
+++ b/cookbook/locale/ru/LC_MESSAGES/django.po
@@ -2501,7 +2501,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:245
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:128

--- a/cookbook/locale/sl/LC_MESSAGES/django.po
+++ b/cookbook/locale/sl/LC_MESSAGES/django.po
@@ -2530,7 +2530,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:229
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:127

--- a/cookbook/locale/tr/LC_MESSAGES/django.po
+++ b/cookbook/locale/tr/LC_MESSAGES/django.po
@@ -2741,7 +2741,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/zh_CN/LC_MESSAGES/django.po
+++ b/cookbook/locale/zh_CN/LC_MESSAGES/django.po
@@ -2855,7 +2855,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:232
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:126

--- a/cookbook/locale/zh_Hant/LC_MESSAGES/django.po
+++ b/cookbook/locale/zh_Hant/LC_MESSAGES/django.po
@@ -2254,7 +2254,7 @@ msgid ""
 msgstr ""
 
 #: .\cookbook\views\new.py:246
-msgid "Email to user could not be send, please share link manually."
+msgid "Email could not be sent to user. Please share the link manually."
 msgstr ""
 
 #: .\cookbook\views\views.py:125

--- a/cookbook/templates/system.html
+++ b/cookbook/templates/system.html
@@ -105,7 +105,7 @@
     <br/>
     <h4>Debug</h4>
     <textarea class="form-control" rows="20">
-Gunicoren Media: {{ gunicorn_media }}
+Gunicorn Media: {{ gunicorn_media }}
 Sqlite: {{ postgres }}
 Debug: {{ debug }}
 

--- a/cookbook/views/new.py
+++ b/cookbook/views/new.py
@@ -227,7 +227,7 @@ class InviteLinkCreate(GroupRequiredMixin, CreateView):
                     messages.add_message(self.request, messages.ERROR,
                                          _('You have send to many emails, please share the link manually or wait a few hours.'))
             except (SMTPException, BadHeaderError, TimeoutError):
-                messages.add_message(self.request, messages.ERROR, _('Email to user could not be send, please share link manually.'))
+                messages.add_message(self.request, messages.ERROR, _('Email could not be sent to user. Please share the link manually.'))
 
         return HttpResponseRedirect(reverse('view_space'))
 


### PR DESCRIPTION
Gunicoren should be Gunicorn
Send should be Sent. (Also reworded more clearly)