### PR TITLE
Update bind mounts in docker run command to use absolute paths

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -14,8 +14,8 @@ It can be run and accessed on port 80 using:
 
 ```shell
 docker run -d \
-    -v ./staticfiles:/opt/recipes/staticfiles \
-    -v ./mediafiles:/opt/recipes/mediafiles \
+    -v "$(pwd)"/staticfiles:/opt/recipes/staticfiles \
+    -v "$(pwd)"/mediafiles:/opt/recipes/mediafiles \
     -p 80:8080 \
     -e SECRET_KEY=YOUR_SECRET_KEY \
     -e DB_ENGINE=django.db.backends.postgresql \


### PR DESCRIPTION
Docker bind mounts have to use absolute paths (https://docs.docker.com/storage/bind-mounts/#start-a-container-with-a-bind-mount).
The `docker run` command as it was in the docs fails when using the relative mounts `./staticfiles` and `./mediafiles.`
Relative path mounts may be supported in the future but not a lot of progress was made there recently (https://github.com/docker/cli/issues/1203)