### PR TITLE
Add POSTGRES_USER to psql health check during boot

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -34,7 +34,7 @@ if [ "${DB_ENGINE}" != 'django.db.backends.sqlite3' ]; then
       display_warning "The environment variable 'POSTGRES_PASSWORD' is not set but REQUIRED for running Tandoor!"
   fi
 
-  while pg_isready --host=${POSTGRES_HOST} --port=${POSTGRES_PORT} -q; status=$?; attempt=$((attempt+1)); [ $status -ne 0 ] && [ $attempt -le $max_attempts ]; do
+  while pg_isready --host=${POSTGRES_HOST} --port=${POSTGRES_PORT} --user=${POSTGRES_USER} -q; status=$?; attempt=$((attempt+1)); [ $status -ne 0 ] && [ $attempt -le $max_attempts ]; do
       sleep 5
   done
 fi


### PR DESCRIPTION
Add POSTGRES_USER to psql health check during boot to support external psql instances better.

Fixes #1656