### PR TITLE
Docs: Reintroduce restart-always to web_recipes service

### DIFF
--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - default
 
   web_recipes:
+    restart: always
     image: vabene1111/recipes
     env_file:
       - ./.env

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - ./.env
 
   web_recipes:
+    restart: always
     image: vabene1111/recipes
     env_file:
       - ./.env

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - default
 
   web_recipes:
+    restart: always
     image: vabene1111/recipes
     env_file:
       - ./.env


### PR DESCRIPTION
Following a support request and discussion in discord this PR aims to reintroduce the `restart: always` policy for the tandoor web-service container in the standard docker-compose.yml.

It is unexpected for new admins or users unfamiliar with docker-compose that all containers except for tandoor-web restart after a reboot.

Restart loops were the reason why `restart: always` was removed in https://github.com/TandoorRecipes/recipes/pull/1498
I think it's acceptable behaviour that such restart loops happen when the configuration is faulty and thus the container crashes.