### PR TITLE
Navbar tweaks

### DIFF
--- a/cookbook/static/css/app.min.css
+++ b/cookbook/static/css/app.min.css
@@ -1,3 +1,7 @@
+.brand-icon {
+    height: 40px;
+}
+
 .spinner-tandoor {
     animation: rotation 3s infinite linear;
     content: url("../assets/spinner.svg");

--- a/cookbook/templates/base.html
+++ b/cookbook/templates/base.html
@@ -60,17 +60,19 @@
 <body>
 
 <nav class="navbar navbar-expand-lg navbar-dark bg-{% nav_color request %} bg-header" id="id_main_nav"
-     style="{% sticky_nav request %}">
+     style="{% sticky_nav request %}"> 
+     
+    {% if not request.user.is_authenticated or request.user.userpreference.theme == request.user.userpreference.TANDOOR %}
+    <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}" aria-label="Tandoor">
+        <img class="brand-icon" src="{% static 'assets/brand_logo.svg' %}" alt="Logo">
+    </a>
+    {% endif %}
+        
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarText"
             aria-controls="navbarText" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
     </button>
 
-    {% if not request.user.is_authenticated or request.user.userpreference.theme == request.user.userpreference.TANDOOR %}
-        <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}" aria-label="Tandoor">
-            <img class="brand-icon" src="{% static 'assets/brand_logo.png' %}" alt="" style="height: 5vh;">
-        </a>
-    {% endif %}
     <div class="collapse navbar-collapse" id="navbarText">
         <ul class="navbar-nav mr-auto">
             <li class="nav-item {% if request.resolver_match.url_name in 'view_search' %}active{% endif %}">


### PR DESCRIPTION
The navbar logo had a height of `5vh` wich ich relative to the screen size and results in a very big logo on bigger screens like a 1440p screen (see first image). This PR does two things to make the logo look better on multiple screens.

- Use a fixed height, in this case `40px` for every screen size.
- Use the already existing `svg` image instead of the `png` wich can get blurry depending on the scaling.

Additionally I swapped the logo and menu button on mobile screens. Since there is no Navigation Drawer as known from Material design, there is no point in moving the Logo to the right on mobile. It looks more consistent if the logo stays at the same place for all screen sizes.

I'd like to hear what you think about these changes.

### 1440p screen
old:
<img src="https://user-images.githubusercontent.com/9558391/162578072-099354ea-fa41-4c8b-a55d-e7040529be29.png" alt="drawing" width="600"/>
new:
<img src="https://user-images.githubusercontent.com/9558391/162578073-6d6ab346-84ee-44cc-839e-176014c3dcdc.png" alt="drawing" width="600"/>

### Mobile screen
old:
<img src="https://user-images.githubusercontent.com/9558391/162578075-31100d5c-88d2-4dae-bb42-de740d6e18da.png" alt="drawing" width="200"/>
new:
<img src="https://user-images.githubusercontent.com/9558391/162578074-6b5e10b5-0062-45ba-8cc9-da6775b4d227.png" alt="drawing" width="200"/>