### PR TITLE
Remove namespace vom k8s templates

### DIFF
--- a/docs/install/k8s/10-configmap.yaml
+++ b/docs/install/k8s/10-configmap.yaml
@@ -4,7 +4,6 @@ metadata:
   labels:
     app: recipes
   name: recipes-nginx-config
-  namespace: default
 data:
   nginx-config: |-
     events {

--- a/docs/install/k8s/15-secrets.yaml
+++ b/docs/install/k8s/15-secrets.yaml
@@ -2,7 +2,6 @@ kind: Secret
 apiVersion: v1
 metadata:
   name: recipes
-  namespace: default
 type: Opaque
 data:
   # echo -n 'db-password' | base64

--- a/docs/install/k8s/20-service-account.yaml
+++ b/docs/install/k8s/20-service-account.yaml
@@ -2,4 +2,3 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: recipes
-  namespace: default

--- a/docs/install/k8s/30-pvc.yaml
+++ b/docs/install/k8s/30-pvc.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: recipes-media
-  namespace: default
   labels:
     app: recipes
 spec:
@@ -16,7 +15,6 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: recipes-static
-  namespace: default
   labels:
     app: recipes
 spec:

--- a/docs/install/k8s/40-sts-postgresql.yaml
+++ b/docs/install/k8s/40-sts-postgresql.yaml
@@ -5,7 +5,6 @@ metadata:
     app: recipes
     tier: database
   name: recipes-postgresql
-  namespace: default
 spec:
   replicas: 1
   selector:
@@ -22,7 +21,6 @@ spec:
         app: recipes
         tier: database
       name: recipes-postgresql
-      namespace: default
     spec:
       containers:
       - name: recipes-db
@@ -124,7 +122,6 @@ spec:
     kind: PersistentVolumeClaim
     metadata:
       name: data
-      namespace: default
     spec:
       accessModes:
       - ReadWriteOnce

--- a/docs/install/k8s/45-service-db.yaml
+++ b/docs/install/k8s/45-service-db.yaml
@@ -5,7 +5,6 @@ metadata:
     app: recipes
     tier: database
   name: recipes-postgresql
-  namespace: default
 spec:
   ports:
   - name: postgresql

--- a/docs/install/k8s/50-deployment.yaml
+++ b/docs/install/k8s/50-deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: recipes
-  namespace: default
   labels:
     app: recipes
     environment: production

--- a/docs/install/k8s/60-service.yaml
+++ b/docs/install/k8s/60-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: recipes
-  namespace: default
   labels:
     app: recipes
     tier: frontend

--- a/docs/install/k8s/70-ingress.yaml
+++ b/docs/install/k8s/70-ingress.yaml
@@ -5,7 +5,6 @@ metadata:
     #cert-manager.io/cluster-issuer: letsencrypt-prod
     #kubernetes.io/ingress.class: nginx
   name: recipes
-  namespace: default
 spec:
   rules:
   - host: recipes.local


### PR DESCRIPTION
The namespace prevents installing into a custom namespace. 
Also, "default" is the default namespace and does not need to be specified.