### PR TITLE
Fix link in German locale

### DIFF
--- a/cookbook/locale/de/LC_MESSAGES/django.po
+++ b/cookbook/locale/de/LC_MESSAGES/django.po
@@ -2467,7 +2467,7 @@ msgid ""
 msgstr ""
 "Das direkte ausliefern von Mediendateien mit gunicorn/python ist <b>nicht "
 "empfehlenswert</b>! Bitte folge den beschriebenen Schritten <a href=\"https"
-"\\://github.com/vabene1111/recipes/releases/tag/0.8.1\">hier</a>, um Ihre "
+"://github.com/vabene1111/recipes/releases/tag/0.8.1\">hier</a>, um Ihre "
 "Installation zu aktualisieren.\n"
 "        "
 


### PR DESCRIPTION
This fixes a link in the German locale, similar to #1698. I guess the proper way would be to fix this in Weblate but I have no access there. So feel free to merge this PR or apply the changes in Weblate, whatever is easier for you.