### PR TITLE
Build armv7 with piwheel wheels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine3.15
+FROM python:3.9-alpine3.15
 
 #Install all dependencies.
 RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography openldap
@@ -14,6 +14,11 @@ RUN mkdir /opt/recipes
 WORKDIR /opt/recipes
 
 COPY requirements.txt ./
+
+RUN \
+    if [ `apk --print-arch` = "armv7" ]; then \
+    printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+    fi
 
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev libressl-dev libffi-dev cargo openssl-dev openldap-dev python3-dev && \
     echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \


### PR DESCRIPTION
I tested out building the armv7 docker image with the prebuilt piwheels images. This seems to fix the compiling issues.

One downside is, that piwheels.org only provides wheels for python 3.9, so I had to downgrade the base-image to `python:3.9-alpine3.15`

We could maybe keep all architectures besides `armv7` on python3.10 so that there are no side effects for other architectures