### PR TITLE
Build pillow for armv7/ raspi

### DIFF
--- a/Dockerfile-raspi
+++ b/Dockerfile-raspi
@@ -2,7 +2,7 @@
 FROM python:3.9-alpine3.15
 
 #Install all dependencies.
-RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography openldap
+RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev py-cryptography openldap gcompat
 
 #Print all logs without buffering it.
 ENV PYTHONUNBUFFERED 1
@@ -15,19 +15,16 @@ RUN mkdir /opt/recipes
 WORKDIR /opt/recipes
 
 COPY requirements.txt ./
-
 RUN \
     if [ `apk --print-arch` = "armv7" ]; then \
     printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
-
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev openssl-dev libffi-dev cargo openldap-dev python3-dev && \
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev zlib-dev jpeg-dev libwebp-dev python3-dev && \
     echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \
     python -m venv venv && \
     /opt/recipes/venv/bin/python -m pip install --upgrade pip && \
     venv/bin/pip install wheel==0.37.1 && \
-    venv/bin/pip install setuptools_rust==1.1.2 && \
-    venv/bin/pip install -r requirements.txt --no-cache-dir &&\
+    venv/bin/pip install -r requirements.txt --no-cache-dir --no-binary=Pillow && \
     apk --purge del .build-deps
 
 #Copy project and execute it.


### PR DESCRIPTION
This fixes the runtime errors of missing libs for the raspberry armv7 docker image.

I also excluded some unnecessary build dependencies.

I could only test it with qemu emulation and only with sqlite so maybe it should still be considered beta-ish. There could be some runtime problems because the piwheels wheels are built for raspbian and not for alpine.