### PR TITLE
Fix import with recipe-scrapers

### DIFF
--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -114,7 +114,14 @@ def get_from_scraper(scrape, request):
         except Exception:
             pass
 
-    if source_url := scrape.url:
+    try:
+        source_url = scrape.canonical_url()
+    except Exception:
+        try: 
+            source_url = scrape.url
+        except Exception:
+            pass
+    if source_url:
         recipe_json['source_url'] = source_url
         try:
             keywords.append(source_url.replace('http://', '').replace('https://', '').split('/')[0])
@@ -129,9 +136,11 @@ def get_from_scraper(scrape, request):
     ingredient_parser = IngredientParser(request, True)
 
     recipe_json['steps'] = []
-
-    for i in parse_instructions(scrape.instructions()):
-        recipe_json['steps'].append({'instruction': i, 'ingredients': [], })
+    try:
+        for i in parse_instructions(scrape.instructions()):
+            recipe_json['steps'].append({'instruction': i, 'ingredients': [], })
+    except Exception:
+        pass
     if len(recipe_json['steps']) == 0:
         recipe_json['steps'].append({'instruction': '', 'ingredients': [], })
 

--- a/cookbook/helper/scrapers/scrapers.py
+++ b/cookbook/helper/scrapers/scrapers.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup
 from json import JSONDecodeError
-from recipe_scrapers import SCRAPERS, get_host_name
+from recipe_scrapers import SCRAPERS 
 from recipe_scrapers._factory import SchemaScraperFactory
 from recipe_scrapers._schemaorg import SchemaOrg
 
@@ -15,13 +15,7 @@ SCRAPERS.update(CUSTOM_SCRAPERS)
 
 
 def text_scraper(text, url=None):
-    domain = None
-    if url:
-        domain = get_host_name(url)
-    if domain in SCRAPERS:
-        scraper_class = SCRAPERS[domain]
-    else:
-        scraper_class = SchemaScraperFactory.SchemaScraper
+    scraper_class = SchemaScraperFactory.SchemaScraper
 
     class TextScraper(scraper_class):
         def __init__(


### PR DESCRIPTION
This PR fixes several import problems which stem from using some internal recipe-scrapers classes.

Overview over changes:
* If an url is provided, scrape_me is called in wild mode
  * If a scraper for the url exists, this scraper is called by recipe-scrapers
  * If no scraper exists wild_mode comes into effect and tries to search the page for schema.org fields.
* If this is unsuccesfull or no url was provided (which happens when data is entered in the source field) the old way of wrapping the input into `<script type='application/ld+json'> ... </script>` and then sending this into recipe-scrapers is used. (This is now the only way how `text_scraper` in `cookbook/helper/scrapers/scrapers.py` gets called)

* Additionally, we always try to get data from the property classes first. If that fails we try to get it from the schema attributes.

This doesn't change a lot of the old behaviour but uses the scraper classes of recipe-scrapers better. This way it shouldn't break anything for any sites. 

Fixes:
* fixes #1764
* https://www.reddit.com/r/selfhosted/comments/ui6cny/tandoor_recipe_v14_released_shopping_importing/i7kkz9a/?context=3 doesn't throw an exception anymore. The issue is within upstream though, so it should be raised there.

I'm not sure what to do about the CooksIllustrated custom scrapers and if they still work. 
@smilerz  Why was this implemented within tandoor and not within recipe-scrapers and is this still working?