### PR TITLE
Add S3_CUSTOM_DOMAIN settings, closes #1943

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -77,6 +77,7 @@ GUNICORN_MEDIA=0
 # S3_QUERYSTRING_AUTH=1 # default true, set to 0 to serve media from a public bucket without signed urls
 # S3_QUERYSTRING_EXPIRE=3600 # number of seconds querystring are valid for
 # S3_ENDPOINT_URL= # when using a custom endpoint like minio
+# S3_CUSTOM_DOMAIN= # when using a CDN/proxy to S3 (see https://github.com/TandoorRecipes/recipes/issues/1943)
 
 # Email Settings, see https://docs.djangoproject.com/en/3.2/ref/settings/#email-host
 # Required for email confirmation and password reset (automatically activates if host is set)

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -408,6 +408,8 @@ if os.getenv('S3_ACCESS_KEY', ''):
 
     if os.getenv('S3_ENDPOINT_URL', ''):
         AWS_S3_ENDPOINT_URL = os.getenv('S3_ENDPOINT_URL', '')
+    if os.getenv('S3_CUSTOM_DOMAIN', ''):
+        AWS_S3_CUSTOM_DOMAIN = os.getenv('S3_CUSTOM_DOMAIN', '')
 
     MEDIA_URL = os.getenv('MEDIA_URL', '/media/')
     MEDIA_ROOT = os.path.join(BASE_DIR, "mediafiles")


### PR DESCRIPTION
Add a setting for https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#cloudfront `AWS_S3_CUSTOM_DOMAIN`. This instructs django to use a different domain than the S3 endpoint in image url's.

This fixes #1943 in the sense that setups with a private S3 can setup a public proxy (with limited access rights) to this proxy.