### PR TITLE
fixed csrf

### DIFF
--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -52,6 +52,9 @@ SHOPPING_MIN_AUTOSYNC_INTERVAL = int(os.getenv('SHOPPING_MIN_AUTOSYNC_INTERVAL',
 
 ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS').split(',') if os.getenv('ALLOWED_HOSTS') else ['*']
 
+if os.getenv('CSRF_TRUSTED_ORIGINS'):
+    CSRF_TRUSTED_ORIGINS = os.getenv('CSRF_TRUSTED_ORIGINS').split(',')
+
 CORS_ORIGIN_ALLOW_ALL = True
 
 LOGIN_REDIRECT_URL = "index"


### PR DESCRIPTION
Added in Django 4.0: CsrfViewMiddleware verifies the [Origin header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Origin), if provided by the browser, against the current host and the [CSRF_TRUSTED_ORIGINS](https://docs.djangoproject.com/en/4.0/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS) setting. This provides protection against cross-subdomain attacks.

It broke this mechanism for installations behind proxy when origin is forwarded. 