### PR TITLE
Fix 'markdown' 3.4 version incompatibility 

### DIFF
--- a/cookbook/helper/mdx_urlize.py
+++ b/cookbook/helper/mdx_urlize.py
@@ -73,9 +73,9 @@ class UrlizePattern(markdown.inlinepatterns.Pattern):
 class UrlizeExtension(markdown.Extension):
     """ Urlize Extension for Python-Markdown. """
 
-    def extendMarkdown(self, md, md_globals):
+    def extendMarkdown(self, md):
         """ Replace autolink with UrlizePattern """
-        md.inlinePatterns['autolink'] = UrlizePattern(URLIZE_RE, md)
+        md.inlinePatterns.register(UrlizePattern(URLIZE_RE, md), 'autolink', 120)
 
 
 def makeExtension(*args, **kwargs):


### PR DESCRIPTION
See [the release notes](https://github.com/Python-Markdown/markdown/blob/master/docs/change_log/release-3.4.md#previously-deprecated-objects-have-been-removed) about the removal of the deprecated argument.