### PR TITLE
Remove yellow button to unify GUI of reset password in mobile/web viewports #2102

### DIFF
--- a/cookbook/templates/account/login.html
+++ b/cookbook/templates/account/login.html
@@ -35,9 +35,7 @@
                 {% endif %}
 
                 {% if EMAIL_ENABLED %}
-                    <a class="btn btn-warning float-right d-none d-xl-block d-lg-block"
-                       href="{% url 'account_reset_password' %}">{% trans "Reset My Password" %}</a>
-                    <p class="d-xl-none d-lg-none">{% trans 'Lost your password?' %} <a
+                    <p>{% trans 'Lost your password?' %} <a
                             href="{% url 'account_reset_password' %}">{% trans "Reset My Password" %}</a></p>
                 {% endif %}
             </form>


### PR DESCRIPTION
Here is my suggestion for the Login page GUI: removing the yellow button unifies the UI in mobile/web view. I think that the user is more familiar with this UI since most of the reset password buttons are composed by some plain text and a `<a>` tag (not colored buttons).
![image](https://user-images.githubusercontent.com/41189322/194039541-b42162aa-4ad3-4355-b47c-12dc4e8a1e9a.png)

_hacktoberfest 2022 entry_
