### PR TITLE
Fix share permission check

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1382,7 +1382,7 @@ def sync_all(request):
 
 
 def share_link(request, pk):
-    if request.space.allow_sharing and has_group_permission(request.user, 'user'):
+    if request.space.allow_sharing and has_group_permission(request.user, ('user',)):
         recipe = get_object_or_404(Recipe, pk=pk, space=request.space)
         link = ShareLink.objects.create(recipe=recipe, created_by=request.user, space=request.space)
         return JsonResponse({'pk': pk, 'share': link.uuid,


### PR DESCRIPTION
I got an error `"sharing_disabled"` when I tried to share a recipe (sharing was enabled and I'm a member of the user group). The reason seems to be that the permission check uses `has_group_permission` with `'user'` instead of `('user',)` (it was interpreted as a list of characters).