### PR TITLE
Fixed: Scroll problem in the navbar on desktop

### DIFF
--- a/cookbook/static/themes/tandoor.min.css
+++ b/cookbook/static/themes/tandoor.min.css
@@ -3220,6 +3220,11 @@ input[type=button].btn-block, input[type=reset].btn-block, input[type=submit].bt
     left: auto
 }
 
+#id_main_nav {
+    height: 400px;
+    overflow: auto;
+}
+
 @media (min-width: 576px) {
     .dropdown-menu-sm-left {
         right: auto;


### PR DESCRIPTION
The main navbar was not scrollable, it just went under the screen. 
Provided it a height of 400px (please increase if you want) and overflow: auto. 

![image](https://user-images.githubusercontent.com/60311647/196270299-0f062494-ff01-4d42-8e93-249fd1fdc9b0.png)
