### PR TITLE
Enable search plugin for docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ markdown_extensions:
 
 plugins:
   - include-markdown
+  - search
 
 nav:
   - Home: 'index.md'


### PR DESCRIPTION
I think mkdocs-material's search function would be a great addition to make the documentation even more accessible. At least I was looking for some info just moments ago and would've liked a search bar.

From my own projects, I remembered that mkdocs-material does come with the search search plugin enabled by default. But it must be re-added to mkdocs.yml when other plugins are used. So I did. Hope this helps. :)