### PR TITLE
add logs detailing deserialization errors for default recipe import

### DIFF
--- a/cookbook/integration/default.py
+++ b/cookbook/integration/default.py
@@ -29,6 +29,9 @@ class Default(Integration):
             recipe = serialized_recipe.save()
             return recipe
 
+        print(json.dumps(data, indent=2))
+        print(json.dumps(serialized_recipe.errors, indent=2))
+
         return None
 
     def get_file_from_recipe(self, recipe):


### PR DESCRIPTION
Hi there, it took me quite a while to figure out exactly why my imports were failing, especially since I'm unfamiliar with django and it's serialization framework. Adding these logs in, which are only output on deserialization failure, made a tremendous difference in my ability to debug imports and would be useful for all forms of installation (especially those such as docker, kubernetes, etc. where editing the source code isn't really a knob you can turn).