### PR TITLE
Fixed: Icons overlapping text in "Foods"

### DIFF
--- a/cookbook/static/themes/tandoor.min.css
+++ b/cookbook/static/themes/tandoor.min.css
@@ -7982,7 +7982,9 @@ a.bg-dark:focus, a.bg-dark:hover, button.bg-dark:focus, button.bg-dark:hover {
 }
 
 .pl-1, .px-1 {
-    padding-left: .25rem !important
+    padding-bottom: 2rem !important;
+    padding-left: 0.25rem !important;
+    padding-top: 2rem !important;
 }
 
 .p-2 {


### PR DESCRIPTION
In "Foods" on the mobile version of the app, the icons for On Hold and Shopping List are no longer overlapping with the ingredient name. We added top and bottom padding to isolate icons so that they are shown under the ingredient name.

<img width="324" alt="image" src="https://user-images.githubusercontent.com/72949553/206765902-a8ed77e6-17da-46f8-be7a-275e731e3c0b.png">

Resolves #2187