### PR TITLE
Allow PWA Manifest to work behind CF Access / certain proxy configs

### DIFF
--- a/cookbook/templates/base.html
+++ b/cookbook/templates/base.html
@@ -19,7 +19,7 @@
     <link rel="mask-icon" href="{% static 'assets/safari-pinned-tab.svg' %}" color="#161616">
     <link rel="apple-touch-icon" href="{% static 'assets/apple-touch-icon.png' %}" sizes="180x180">
 
-    <link rel="manifest" href="{% url 'web_manifest' %}">
+    <link rel="manifest" crossorigin="use-credentials" href="{% url 'web_manifest' %}">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="msapplication-TileImage" content="/mstile-144x144.png">
 


### PR DESCRIPTION
I am running this app behind Cloudflare Access. Cloudflare Access (and potentially other proxies) ensure that there is a specific authorization cookie on each request going through the proxy. Requests without this cookie get redirected to the login page, or blocked.

It appears that from spec when using a `link` tag _specifically with_ `rel="manifest"` the cors `crossorigin` attribute is set to anonymous/omit and cookies are stripped from the request by the browser. This is documented here: https://github.com/w3c/manifest/issues/535 with links to several other apps that have implemented similar solutions.

This change allows the browser to pass cookies with the request and properly retrieve the manifest.json file, which allows the PWA to be installed as expected. 