### PR TITLE
Fix path traversal in manual installation steps

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -180,11 +180,11 @@ server {
     #error_log /var/log/nginx/error.log;
 
     # serve media files
-    location /static {
+    location /static/ {
         alias /var/www/recipes/staticfiles;
     }
     
-    location /media {
+    location /media/ {
         alias /var/www/recipes/mediafiles;
     }
 


### PR DESCRIPTION
[According to gixy](https://github.com/yandex/gixy/blob/master/docs/en/plugins/aliastraversal.md) the example nginx config for manual installation is vulnerable to a path traversal attack