### PR TITLE
Updating/improving kubernetes deployment and its documentation

### DIFF
--- a/docs/install/k8s/50-deployment.yaml
+++ b/docs/install/k8s/50-deployment.yaml
@@ -49,7 +49,7 @@ spec:
               secretKeyRef:
                 name: recipes
                 key: postgresql-postgres-password
-        image: vabene1111/recipes:1.0.1
+        image: vabene1111/recipes
         imagePullPolicy: Always
         resources:
           requests:
@@ -110,7 +110,7 @@ spec:
             subPath: nginx-config
             readOnly: true
       - name: recipes
-        image: vabene1111/recipes:1.0.1
+        image: vabene1111/recipes
         imagePullPolicy: IfNotPresent
         command:
           - /opt/recipes/venv/bin/gunicorn
@@ -159,6 +159,8 @@ spec:
               secretKeyRef:
                 name: recipes
                 key: secret-key
+          - name: GUNICORN_MEDIA
+            value: "0"
           - name: DB_ENGINE
             value: django.db.backends.postgresql_psycopg2
           - name: POSTGRES_HOST

--- a/docs/install/kubernetes.md
+++ b/docs/install/kubernetes.md
@@ -61,6 +61,14 @@ The deployment first fires up a init container to do the database migrations and
 
 The deployment then runs two containers, the recipes-nginx and the recipes container which runs the gunicorn app. The nginx container gets it's nginx.conf via config map to deliver static content `/static` and `/media`. The guincorn container gets it's secret key and the database password from the secret `recipes`. `gunicorn` runs as user `nobody`.
 
+Currently, this deployment is using the `latest` image. You may want to explicitly set the tag, e.g.
+
+~~~
+image: vabene1111/recipes:1.4.7
+~~~
+
+It is **extremely important** to use the same image in both the initialization `init-chmod-data` and the main `recipes` containers.
+
 ### 60-service.yaml
 
 Creating the app service.
@@ -91,7 +99,9 @@ I don't know how this check works, but this warning is simply wrong! ;-) Media a
 
 ## Updates
 
-These manifests are tested against Release 1.0.1. Newer versions may not work without changes.
+These manifests have been tested for several releases. Newer versions may not work without changes.
+
+If everything works as expected, the `init-chmod-data` initialization container performs the database migration and the update procedure is transparent. However, it is recommended to use specific tags to increase stability and avoid unnecessary migrations.
 
 ## Apply the manifets
 


### PR DESCRIPTION
The documentation for kubernetes is fine, but it used the 1.0.1 release as its base.

I believe that leaving `latest` with some explicit recommendations is good enough in this context.

Also, a minor thing, because nginx is deployed, `GUNICORN_MEDIA=0` seems to be a sane default (and removes the warning on recipes.local/system/ Media Serving section).