### PR TITLE
Skip Docker push for Dependabot PRs

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -69,11 +69,13 @@ jobs:
         uses: docker/setup-buildx-action@v2
       - name: Login to Docker Hub
         uses: docker/login-action@v2
+        if: github.secret_source == 'Actions'
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
+        if: github.secret_source == 'Actions'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -100,7 +102,7 @@ jobs:
           context: .
           file: ${{ matrix.dockerfile }}
           pull: true
-          push: true
+          push: ${{ github.secret_source == 'Actions' }}
           platforms: ${{ matrix.platforms }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR addresses an issue where CI has been failing for Dependabot PRs after #2376. The failure is occurring because Dependabot PRs use a separate secret source.

To resolve this, I've added `if: github.secret_source == 'Actions'` so that DockerHub and GHCR login steps are skipped for Dependabot PRs. Additionally, I've set `push: ${{ github.secret_source == 'Actions' }}` to build Docker images, but skip the push stage.

Although GHCR login would still pass for Dependabot PRs, I added the if statement to both DockerHub and GHCR login steps for consistency.