### PR TITLE
enable toolbar seperate from debug logging

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -2,6 +2,7 @@
 # when unset: 1 (true) - dont unset this, just for development
 DEBUG=0
 SQL_DEBUG=0
+DEBUG_TOOLBAR=0
 
 # HTTP port to bind to
 # TANDOOR_PORT=8080

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -25,6 +25,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.getenv('SECRET_KEY') if os.getenv('SECRET_KEY') else 'INSECURE_STANDARD_KEY_SET_IN_ENV'
 
 DEBUG = bool(int(os.getenv('DEBUG', True)))
+DEBUG_TOOLBAR = bool(int(os.getenv('DEBUG_TOOLBAR', True)))
 
 SOCIAL_DEFAULT_ACCESS = bool(int(os.getenv('SOCIAL_DEFAULT_ACCESS', False)))
 SOCIAL_DEFAULT_GROUP = os.getenv('SOCIAL_DEFAULT_GROUP', 'guest')
@@ -158,7 +159,7 @@ MIDDLEWARE = [
     'cookbook.helper.scope_middleware.ScopeMiddleware',
 ]
 
-if DEBUG:
+if DEBUG_TOOLBAR:
     MIDDLEWARE += ('debug_toolbar.middleware.DebugToolbarMiddleware',)
     INSTALLED_APPS += ('debug_toolbar',)
 


### PR DESCRIPTION
I like running on debug mode all of the time, but the toolbar adds a very noticeable drag on performance (plus my other users don't need to see it)

This lets you turn on debug and the toolbar seperately.