### PR TITLE
ldap auth: allow connecting using StartTLS

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -147,6 +147,7 @@ REVERSE_PROXY_AUTH=0
 #AUTH_LDAP_BIND_PASSWORD=
 #AUTH_LDAP_USER_SEARCH_BASE_DN=
 #AUTH_LDAP_TLS_CACERTFILE=
+#AUTH_LDAP_START_TLS=
 
 # Enables exporting PDF (see export docs)
 # Disabled by default, uncomment to enable

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -96,6 +96,7 @@ AUTH_LDAP_USER_SEARCH_FILTER_STR=(uid=%(user)s)
 AUTH_LDAP_USER_ATTR_MAP={'first_name': 'givenName', 'last_name': 'sn', 'email': 'mail'}
 AUTH_LDAP_ALWAYS_UPDATE_USER=1
 AUTH_LDAP_CACHE_TIMEOUT=3600
+AUTH_LDAP_START_TLS=1
 AUTH_LDAP_TLS_CACERTFILE=/etc/ssl/certs/own-ca.pem
 ```
 

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -172,6 +172,7 @@ if LDAP_AUTH:
     from django_auth_ldap.config import LDAPSearch
     AUTHENTICATION_BACKENDS.append('django_auth_ldap.backend.LDAPBackend')
     AUTH_LDAP_SERVER_URI = os.getenv('AUTH_LDAP_SERVER_URI')
+    AUTH_LDAP_START_TLS = bool(int(os.getenv('AUTH_LDAP_START_TLS', False)))
     AUTH_LDAP_BIND_DN = os.getenv('AUTH_LDAP_BIND_DN')
     AUTH_LDAP_BIND_PASSWORD = os.getenv('AUTH_LDAP_BIND_PASSWORD')
     AUTH_LDAP_USER_SEARCH = LDAPSearch(


### PR DESCRIPTION
Currently connctions to LDAP servers which require secure connections initiated via StartTLS are not possible. This change adds the environment option `AUTH_LDAP_START_TLS` and forwards it to the ldap provider (https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-start-tls), so one can optionally enable StartTLS.