### PR TITLE
Fix stable release Discord notification

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -115,13 +115,17 @@ jobs:
     needs: build-container
     if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Set tag name
+        run: |
+          # Strip "refs/tags/" prefix
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
       # Send stable discord notification
       - name: Discord notification
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
         uses: Ilshidur/action-discord@0.3.2
         with:
-          args: '🚀 Version {{ EVENT_PAYLOAD.release.tag_name }} of tandoor has been released 🥳 Check it out https://github.com/vabene1111/recipes/releases/tag/{{ EVENT_PAYLOAD.release.tag_name }}'
+          args: '🚀 Version {{ VERSION }} of tandoor has been released 🥳 Check it out https://github.com/vabene1111/recipes/releases/tag/{{ VERSION }}'
 
   notify-beta:
     name: Notify Beta


### PR DESCRIPTION
This PR fixes #2436 by using `GITHUB_REF` instead of relying on a release event payload.

This is untested since I don't have a Discord bot set up, but I'll attempt a release in my fork and ensure the env gets set correctly. The docs for [Ilshidur/action-discord](https://github.com/Ilshidur/action-discord#arguments) say that `{{ ... }}` can be used for environment variables, so this _should_ work just fine.