### PR TITLE
Fix multiple file field

### DIFF
--- a/cookbook/forms.py
+++ b/cookbook/forms.py
@@ -167,8 +167,25 @@ class ImportExportBase(forms.Form):
     ))
 
 
+class MultipleFileInput(forms.ClearableFileInput):
+    allow_multiple_selected = True
+
+
+class MultipleFileField(forms.FileField):
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("widget", MultipleFileInput())
+        super().__init__(*args, **kwargs)
+
+    def clean(self, data, initial=None):
+        single_file_clean = super().clean
+        if isinstance(data, (list, tuple)):
+            result = [single_file_clean(d, initial) for d in data]
+        else:
+            result = single_file_clean(data, initial)
+        return result
+
 class ImportForm(ImportExportBase):
-    files = forms.FileField(required=True, widget=forms.ClearableFileInput(attrs={'multiple': True}))
+    files = MultipleFileField(required=True)
     duplicates = forms.BooleanField(help_text=_(
         'To prevent duplicates recipes with the same name as existing ones are ignored. Check this box to import everything.'),
         required=False)


### PR DESCRIPTION
Due to [1], the previous solution does not work on recent Django releases.

See [2] for the documented work-around, as applied in this commit.

Closes #2457.

[1]: https://docs.djangoproject.com/en/4.2/releases/4.2.1/
[2]: https://docs.djangoproject.com/en/4.2/topics/http/file-uploads/#uploading-multiple-files