### PR TITLE
Enable gunicorn debug log

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,6 +3,9 @@
 DEBUG=0
 SQL_DEBUG=0
 DEBUG_TOOLBAR=0
+# Gunicorn log level for debugging (default value is "info" when unset)
+# (see https://docs.gunicorn.org/en/stable/settings.html#loglevel for available settings)
+# GUNICORN_LOG_LEVEL="debug"
 
 # HTTP port to bind to
 # TANDOOR_PORT=8080

--- a/boot.sh
+++ b/boot.sh
@@ -4,6 +4,7 @@ source venv/bin/activate
 TANDOOR_PORT="${TANDOOR_PORT:-8080}"
 GUNICORN_WORKERS="${GUNICORN_WORKERS:-3}"
 GUNICORN_THREADS="${GUNICORN_THREADS:-2}"
+GUNICORN_LOG_LEVEL="${GUNICORN_LOG_LEVEL:-'info'}"
 NGINX_CONF_FILE=/opt/recipes/nginx/conf.d/Recipes.conf
 
 display_warning() {
@@ -65,4 +66,4 @@ echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 
-exec gunicorn -b :$TANDOOR_PORT --workers $GUNICORN_WORKERS --threads $GUNICORN_THREADS --access-logfile - --error-logfile - --log-level INFO recipes.wsgi
+exec gunicorn -b :$TANDOOR_PORT --workers $GUNICORN_WORKERS --threads $GUNICORN_THREADS --access-logfile - --error-logfile - --log-level $GUNICORN_LOG_LEVEL recipes.wsgi


### PR DESCRIPTION
While helping to debug some gunicorn startup issues I realized that the gunicorn log level was not yet configurable. So I modified the .env file and boot.sh script to make the gunicorn loglevel configurable by setting the `GUNICORN_LOG_LEVEL` variable. 

We could maybe also use the DEBUG variable to modify the gunicorn log level as well I'm open to both possibilities.