### PR TITLE
Fix bottom navigation not hiding in print mode

### DIFF
--- a/vue/src/components/BottomNavigationBar.vue
+++ b/vue/src/components/BottomNavigationBar.vue
@@ -1,6 +1,6 @@
 <template>
     <!-- bottom button nav -->
-    <div class="fixed-bottom p-1 pt-2 pl-2 pr-2 border-top text-center d-lg-none" style="background: white">
+    <div class="fixed-bottom p-1 pt-2 pl-2 pr-2 border-top text-center d-lg-none d-print-none" style="background: white">
         <div class="d-flex flex-row justify-content-around">
             <div class="flex-column" v-if="show_button_1">
                 <slot name="button_1">


### PR DESCRIPTION
Currently, the mobile navigation bar shows up at the bottom of each page when printing, as shown below:
![Screenshot_20230529_114821](https://github.com/TandoorRecipes/recipes/assets/47087725/ee98b463-3661-4558-86c5-b3f4d326b596)
