### PR TITLE
add note to docker-compose files and update postgres tag

### DIFF
--- a/docs/install/docker/ipv6_plain/docker-compose.yml
+++ b/docs/install/docker/ipv6_plain/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2.4"
 services:
   db_recipes:
     restart: always
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ${POSTGRES_DATA_DIR:-./postgresql}:/var/lib/postgresql/data
     env_file:
@@ -22,6 +22,7 @@ services:
       - ./.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/opt/recipes/nginx/conf.d
       - ${MEDIA_FILES_DIR:-./mediafiles}:/opt/recipes/mediafiles
     depends_on:
@@ -41,6 +42,7 @@ services:
     depends_on:
       - web_recipes
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static:ro
       - ${MEDIA_FILES_DIR:-./mediafiles}:/media:ro

--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   db_recipes:
     restart: always
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
@@ -17,6 +17,7 @@ services:
       - ./.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
@@ -32,6 +33,7 @@ services:
     depends_on:
       - web_recipes
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static:ro
       - ./mediafiles:/media:ro

--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   db_recipes:
     restart: always
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
@@ -15,6 +15,7 @@ services:
       - ./.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
@@ -30,6 +31,7 @@ services:
     depends_on:
       - web_recipes
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static:ro
       - ./mediafiles:/media:ro

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   db_recipes:
     restart: always
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
@@ -17,6 +17,7 @@ services:
       - ./.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
@@ -30,6 +31,7 @@ services:
     env_file:
       - ./.env
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static:ro
       - ./mediafiles:/media:ro

--- a/docs/install/swag.md
+++ b/docs/install/swag.md
@@ -69,7 +69,7 @@ services:
   db_recipes:
     restart: always
     container_name: db_recipes
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ./recipes/db:/var/lib/postgresql/data
     env_file:

--- a/docs/install/truenas_portainer.md
+++ b/docs/install/truenas_portainer.md
@@ -80,7 +80,7 @@ Basic guide to setup Docker and Portainer TrueNAS Core.
 services:
   db_recipes:
     restart: always
-    image: postgres:11-alpine
+    image: postgres:15-alpine
     volumes:
       - ./postgresql:/var/lib/postgresql/data
     env_file:
@@ -93,7 +93,8 @@ services:
       - stack.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
-      - nginx_config:/opt/recipes/nginx/conf.d
+	  # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
+      - nginx_config:/opt/recipes/nginx/conf.d 
       - ./mediafiles:/opt/recipes/mediafiles
     depends_on:
       - db_recipes
@@ -108,6 +109,7 @@ services:
     depends_on:
       - web_recipes
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
       - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static
       - ./mediafiles:/media


### PR DESCRIPTION
These are some small Improvements to the docker-compose files in the docs:

1. Postgres version 11 is the default in the docker-compose files and its support will end in [November](https://www.postgresql.org/support/versioning/). Is there any reason against updating it to the most recent version?
2. Since many support requests in the discord boil down to the fact that the nginx config volume was changed to a bind mount and nginx can't find its config anymore, I added a small disclaimer which should make it clear that it shouldn't be changed without consideration.