### PR TITLE
Add source URL to recipe export

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1362,7 +1362,7 @@ class RecipeExportSerializer(WritableNestedModelSerializer):
         model = Recipe
         fields = (
             'name', 'description', 'keywords', 'steps', 'working_time',
-            'waiting_time', 'internal', 'nutrition', 'servings', 'servings_text',
+            'waiting_time', 'internal', 'nutrition', 'servings', 'servings_text', 'source_url',
         )
 
     def create(self, validated_data):


### PR DESCRIPTION
This adds the `source_url` field to the recipe export. It's present in other export types (e.g. Paprika) but missing from the default export.