### PR TITLE
allow signup for social accounts when the provider is set up

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -113,7 +113,8 @@ REMOTE_USER_AUTH=0
 # SPACE_DEFAULT_MAX_FILES=0 # Maximum file storage for space in MB. 0 for unlimited, -1 to disable file upload.
 # SPACE_DEFAULT_ALLOW_SHARING=1 # Allow users to share recipes with public links
 
-# allow people to create accounts on your application instance (without an invite link)
+# allow people to create local accounts on your application instance (without an invite link)
+# social accounts will always be able to sign up
 # when unset: 0 (false)
 # ENABLE_SIGNUP=0
 

--- a/cookbook/helper/AllAuthCustomAdapter.py
+++ b/cookbook/helper/AllAuthCustomAdapter.py
@@ -20,7 +20,9 @@ class AllAuthCustomAdapter(DefaultAccountAdapter):
         if 'signup_token' in request.session and InviteLink.objects.filter(valid_until__gte=datetime.datetime.today(), used_by=None, uuid=request.session['signup_token']).exists():
             signup_token = True
 
-        if (request.resolver_match.view_name == 'account_signup' or request.resolver_match.view_name == 'socialaccount_signup') and not settings.ENABLE_SIGNUP and not signup_token:
+        if request.resolver_match.view_name == 'account_signup' and not settings.ENABLE_SIGNUP and not signup_token:
+            return False
+        elif request.resolver_match.view_name == 'socialaccount_signup' and len(settings.SOCIAL_PROVIDERS) < 1:
             return False
         else:
             return super(AllAuthCustomAdapter, self).is_open_for_signup(request)

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -17,6 +17,8 @@ They basically explain everything in their documentation, but the following is a
 Choose a provider from the [list](https://django-allauth.readthedocs.io/en/latest/providers.html) and install it using the environment variable `SOCIAL_PROVIDERS` as shown
 in the example below.
 
+When at least one social provider is set up, the social login sign in buttons should appear on the login page.
+
 ```ini
 SOCIAL_PROVIDERS=allauth.socialaccount.providers.github,allauth.socialaccount.providers.nextcloud
 ```


### PR DESCRIPTION
When a social provider is set up, the social account signup view is enabled. This seems to cover issue #2261, but it needs further testing.