### PR TITLE
Update and add settings

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -13,6 +13,14 @@ DEBUG_TOOLBAR=0
 # hosts the application can run under e.g. recipes.mydomain.com,cooking.mydomain.com,...
 ALLOWED_HOSTS=*
 
+# Cross Site Request Forgery protection
+# (https://docs.djangoproject.com/en/4.2/ref/settings/#std-setting-CSRF_TRUSTED_ORIGINS)
+# CSRF_TRUSTED_ORIGINS = []
+
+# Cross Origin Resource Sharing
+# (https://github.com/adamchainz/django-cors-header)
+# CORS_ALLOW_ALL_ORIGINS = True
+
 # random secret key, use for example `base64 /dev/urandom | head -c50` to generate one
 # ---------------------------- REQUIRED -------------------------
 SECRET_KEY=

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -68,7 +68,11 @@ ALLOWED_HOSTS = os.getenv('ALLOWED_HOSTS').split(
 if os.getenv('CSRF_TRUSTED_ORIGINS'):
     CSRF_TRUSTED_ORIGINS = os.getenv('CSRF_TRUSTED_ORIGINS').split(',')
 
-CORS_ORIGIN_ALLOW_ALL = True
+if CORS_ORIGIN_ALLOW_ALL := os.getenv('CORS_ORIGIN_ALLOW_ALL') is not None:
+    print('DEPRECATION WARNING: Environment var "CORS_ORIGIN_ALLOW_ALL" is deprecated. Please use "CORS_ALLOW_ALL_ORIGINS."')
+    CORS_ALLOW_ALL_ORIGINS = CORS_ORIGIN_ALLOW_ALL
+else:
+    CORS_ALLOW_ALL_ORIGINS = bool(int(os.getenv("CORS_ALLOW_ALL_ORIGINS", True)))
 
 LOGIN_REDIRECT_URL = "index"
 LOGOUT_REDIRECT_URL = "index"


### PR DESCRIPTION
I've been fighting with CORS and CSRF (amongst other things) while trying to get an API call with ajax to work. As such, I found that `CORS_ORIGIN_ALLOW_ALL` was fixed as `True`. I feel that it should be configurable by the user, so I added an `os.getenv` call for it with a default to `True` for no breaking changes. I also updated it per https://github.com/adamchainz/django-cors-headers to `CORS_ALLOW_ALL_ORIGINS`.

I added that and `CSRF_TRUSTED_ORIGINS` to the template .env file for better discoverability, though they're both commented out.

I didn't do a discussion on this first, but I can start one if that would be preferred.