### PR TITLE
Added support for keeping SECRET_KEY and POSTGRES_PASSWORD in a file

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -22,8 +22,9 @@ ALLOWED_HOSTS=*
 # CORS_ALLOW_ALL_ORIGINS = True
 
 # random secret key, use for example `base64 /dev/urandom | head -c50` to generate one
-# ---------------------------- REQUIRED -------------------------
+# ---------------------------- AT LEAST ONE REQUIRED -------------------------
 SECRET_KEY=
+SECRET_KEY_FILE=
 # ---------------------------------------------------------------
 
 # your default timezone See https://timezonedb.com/time-zones for a list of timezones
@@ -35,8 +36,9 @@ DB_ENGINE=django.db.backends.postgresql
 POSTGRES_HOST=db_recipes
 POSTGRES_PORT=5432
 POSTGRES_USER=djangouser
-# ---------------------------- REQUIRED -------------------------
+# ---------------------------- AT LEAST ONE REQUIRED -------------------------
 POSTGRES_PASSWORD=
+POSTGRES_PASSWORD_FILE=
 # ---------------------------------------------------------------
 POSTGRES_DB=djangodb
 

--- a/boot.sh
+++ b/boot.sh
@@ -19,9 +19,14 @@ if [ ! -f "$NGINX_CONF_FILE" ] && [ $GUNICORN_MEDIA -eq 0 ]; then
     display_warning "Nginx configuration file could not be found at the default location!\nPath: ${NGINX_CONF_FILE}"
 fi
 
-# SECRET_KEY must be set in .env file
+# SECRET_KEY (or a valid file at SECRET_KEY_FILE) must be set in .env file
+
+if [ -f "${SECRET_KEY_FILE}" ]; then
+    export SECRET_KEY=$(cat "$SECRET_KEY_FILE")
+fi
+
 if [ -z "${SECRET_KEY}" ]; then
-    display_warning "The environment variable 'SECRET_KEY' is not set but REQUIRED for running Tandoor!"
+    display_warning "The environment variable 'SECRET_KEY' (or 'SECRET_KEY_FILE' that points to an existing file) is not set but REQUIRED for running Tandoor!"
 fi
 
 
@@ -32,9 +37,14 @@ max_attempts=20
 
 if [ "${DB_ENGINE}" != 'django.db.backends.sqlite3' ]; then
 
-  # POSTGRES_PASSWORD must be set in .env file
+  # POSTGRES_PASSWORD (or a valid file at POSTGRES_PASSWORD_FILE) must be set in .env file
+
+  if [ -f "${POSTGRES_PASSWORD_FILE}" ]; then
+    export POSTGRES_PASSWORD=$(cat "$POSTGRES_PASSWORD_FILE")
+  fi
+
   if [ -z "${POSTGRES_PASSWORD}" ]; then
-      display_warning "The environment variable 'POSTGRES_PASSWORD' is not set but REQUIRED for running Tandoor!"
+      display_warning "The environment variable 'POSTGRES_PASSWORD' (or 'POSTGRES_PASSWORD_FILE' that points to an existing file) is not set but REQUIRED for running Tandoor!"
   fi
 
   while pg_isready --host=${POSTGRES_HOST} --port=${POSTGRES_PORT} --user=${POSTGRES_USER} -q; status=$?; attempt=$((attempt+1)); [ $status -ne 0 ] && [ $attempt -le $max_attempts ]; do


### PR DESCRIPTION
This commit adds two optional environment variables:

- SECRET_KEY_FILE
- POSTGRES_PASSWORD_FILE

This change allows mounting secret data when running this in Docker Swarm, instead of having to hard-code it in our docker-compose file or provide it alongside all other environment variables.