### PR TITLE
Make import list layout responsive

### DIFF
--- a/vue/src/apps/ImportView/ImportView.vue
+++ b/vue/src/apps/ImportView/ImportView.vue
@@ -267,10 +267,10 @@
                         <b-tab v-bind:title="$t('App')">
                             <b-container>
                                 <h4>{{ $t('Select_App_To_Import') }}:</h4>
-                                <b-row class="mt-4">
-                                    <b-col cols="4" offset="0" offset-md="4" v-for="i in INTEGRATIONS_TD" :value="i.id"
+                                <b-row align-h="center" class="mt-4">
+                                    <b-col cols="12" md="6" v-for="i in INTEGRATIONS_TD" :value="i.id"
                                            v-bind:key="i.id">
-                                        <b-list-group style="max-width: 300px;">
+                                        <b-list-group>
                                             <b-list-group-item class="d-flex align-items-center" v-hover
                                                                style="cursor: pointer"
                                                                v-bind:class="{ 'bg-success': recipe_app === i.id }"
@@ -297,9 +297,9 @@
                                     </b-col>
                                 </b-row>
                                 <b-row class="mt-4">
-                                    <b-col cols="3" v-for="i in INTEGRATIONS_WO" :value="i.id" v-bind:key="i.id"
+                                    <b-col cols="12" md="6" lg="4" xl="3" v-for="i in INTEGRATIONS_WO" :value="i.id" v-bind:key="i.id"
                                            class="mt-1">
-                                        <b-list-group style="max-width: 300px;">
+                                        <b-list-group>
                                             <b-list-group-item class="d-flex align-items-center" v-hover
                                                                style="cursor: pointer"
                                                                v-bind:class="{ 'bg-success': recipe_app === i.id }"


### PR DESCRIPTION
The page showing the list of apps you can import recipes from could work better on small screens. Here's a gif of the current behaviour:
![current behaviour](https://github.com/TandoorRecipes/recipes/assets/16196364/82630bdf-c2e6-481f-a42e-65d11d2d3b06)

I have added some breakpoints to the grid of apps so that they are easier to read on smaller screens.
![new behaviour](https://github.com/TandoorRecipes/recipes/assets/16196364/582e2a5f-9c37-42f9-aa97-7d05d585e8f5)

Now the names of the apps can be easily read on small screens. However when all the apps are in such a long list it might be confusing for the user to have to scroll down all the way to the bottom to import the file. I think also that maybe when pressing an app the file chooser should open immediately and the bottom section of the page should be removed? Or maybe the bottom part opens as a modal? Despite this potential confusion I think the layout change is still preferable to the current behaviour as right now this page is almost unusable on a phone.