### PR TITLE
Increase specificity of the delete confirmation dialog

### DIFF
--- a/vue/src/apps/RecipeEditView/RecipeEditView.vue
+++ b/vue/src/apps/RecipeEditView/RecipeEditView.vue
@@ -1084,7 +1084,11 @@ export default {
             this.$nextTick(() => document.getElementById(`amount_${this.recipe.steps.indexOf(step)}_${step.ingredients.length - 1}`).select())
         },
         removeIngredient: function (step, ingredient) {
-            if (confirm(this.$t("delete_confirmation", {source: `"${ingredient.food.name}"`}))) {
+            let message = this.$t("confirm_delete", {object: this.$t("Ingredient")})
+            if (ingredient.food?.name) {
+                message = this.$t("delete_confirmation", {source: `"${ingredient.food.name}"`})
+            }
+            if (confirm(message)) {
                 step.ingredients = step.ingredients.filter((item) => item !== ingredient)
             }
         },

--- a/vue/src/apps/RecipeEditView/RecipeEditView.vue
+++ b/vue/src/apps/RecipeEditView/RecipeEditView.vue
@@ -1084,7 +1084,7 @@ export default {
             this.$nextTick(() => document.getElementById(`amount_${this.recipe.steps.indexOf(step)}_${step.ingredients.length - 1}`).select())
         },
         removeIngredient: function (step, ingredient) {
-            if (confirm(this.$t("confirm_delete", {object: this.$t("Ingredient")}))) {
+            if (confirm(this.$t("delete_confirmation", {source: `"${ingredient.food.name}"`}))) {
                 step.ingredients = step.ingredients.filter((item) => item !== ingredient)
             }
         },

--- a/vue/src/apps/RecipeEditView/RecipeEditView.vue
+++ b/vue/src/apps/RecipeEditView/RecipeEditView.vue
@@ -1089,7 +1089,8 @@ export default {
             }
         },
         removeStep: function (step) {
-            if (confirm(this.$t("confirm_delete", {object: this.$t("Step")}))) {
+            const step_index = this.recipe.steps.indexOf(step)
+            if (confirm(this.$t("delete_confirmation", {source: `${this.$t("Step")} "${step.name || step_index}"`}))) {
                 this.recipe.steps = this.recipe.steps.filter((item) => item !== step)
             }
         },


### PR DESCRIPTION
When deleting steps and ingredients I was sometimes unsure which delete button I'd actually pressed. I've tweaked the strings to now tell the user what they're about to delete.

e.g. 
- Steps
  - without a name
    `Are you sure you want to delete this Step?` |-> `Are you sure that you want to delete Step "2"`
  - with a name
    `Are you sure you want to delete this Step?` |-> `Are you sure that you want to delete Step "Prepare vegetables"`

- Ingredients
  - without a name
    `Are you sure you want to delete this Ingredient?` (unchanged)
  - with a name
    `Are you sure you want to delete this Ingredient?` |-> `Are you sure that you want to delete "cloves"`

