### PR TITLE
Make gunicorn and nginx listen to IPv6

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -76,4 +76,4 @@ echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 
-exec gunicorn -b :$TANDOOR_PORT --workers $GUNICORN_WORKERS --threads $GUNICORN_THREADS --access-logfile - --error-logfile - --log-level $GUNICORN_LOG_LEVEL recipes.wsgi
+exec gunicorn -b "[::]:$TANDOOR_PORT" --workers $GUNICORN_WORKERS --threads $GUNICORN_THREADS --access-logfile - --error-logfile - --log-level $GUNICORN_LOG_LEVEL recipes.wsgi

--- a/nginx/conf.d/Recipes.conf
+++ b/nginx/conf.d/Recipes.conf
@@ -1,5 +1,6 @@
 server {
   listen 80;
+  listen [::]:80 ipv6only=on;
   server_name localhost;
 
   client_max_body_size 128M;


### PR DESCRIPTION
## Problem

I'm using tandoor in a docker compose setup. I noticed that nginx sometimes returns a "Bad Gateway" error and logs something like `upstream server temporarily disabled while connecting to upstream`.

Although I'm not entirely sure, I think this might be caused by my IPv4/IPv6 dual stack setup (I've enabled ipv6 on the network created by docker compose). I assume the DNS request from the nginx container sometimes resolves to the IPv6 address of the gunicorn container. The gunicorn container does not listen to IPv6 connections. Therefore, the connection is refused and nginx returns a gateway error.

## Solution

This PR binds gunicorn to `[::]:8080` instead of `:8080`. This should listen on [both IPv4 and IPv6](https://github.com/benoitc/gunicorn/issues/1138#issuecomment-158358666) addresses (as long as `bindv6only` is disabled, which is disabled by default).

I additionally enabled IPv6 for nginx itself.