### PR TITLE
Fix parsing DATABASE_URL with port number

### DIFF
--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -350,7 +350,7 @@ WSGI_APPLICATION = 'recipes.wsgi.application'
 # Load settings from env files
 if os.getenv('DATABASE_URL'):
     match = re.match(
-        r'(?P<schema>\w+):\/\/(?:(?P<user>[\w\d_-]+)(?::(?P<password>[^@]+))?@)?(?P<host>[^:/]+)(?:(?P<port>\d+))?(?:/(?P<database>[\w\d/._-]+))?',
+        r'(?P<schema>\w+):\/\/(?:(?P<user>[\w\d_-]+)(?::(?P<password>[^@]+))?@)?(?P<host>[^:/]+)(?::(?P<port>\d+))?(?:/(?P<database>[\w\d/._-]+))?',
         os.getenv('DATABASE_URL')
     )
     settings = match.groupdict()


### PR DESCRIPTION
A recent change in the DATABASE_URL regex ignores the PORT and DB part when a port number is provided:
![image](https://github.com/TandoorRecipes/recipes/assets/2150982/1546016d-1cbe-4195-8aee-08c71babaa7f)

With this change it parses properly again:
![image](https://github.com/TandoorRecipes/recipes/assets/2150982/640189f4-092c-46ee-b849-26b917749d8c)
