### PR TITLE
Improved Navigation Bar Color Accessibility for Info, Danger and Dark…

### DIFF
--- a/cookbook/static/themes/tandoor.min.css
+++ b/cookbook/static/themes/tandoor.min.css
@@ -4501,16 +4501,48 @@ input[type=button].btn-block, input[type=reset].btn-block, input[type=submit].bt
     color: hsla(0, 0%, 18%, .5)
 }
 
+.bg-dark .navbar-nav .nav-link {
+    color: hsla(0, 0%, 81%, 0.5)
+}
+
+:is(.bg-danger, .bg-info) .navbar-nav .nav-link {
+    color: hsla(0, 0%, 0%, 0.5)
+}
+
 .navbar-dark .navbar-nav .nav-link:focus, .navbar-dark .navbar-nav .nav-link:hover {
     color: hsla(0, 0%, 18%, .75)
+}
+
+.bg-dark .navbar-nav .nav-link:focus, .bg-dark .navbar-nav .nav-link:hover {
+    color: hsla(0, 0%, 81%, 0.75)
+}
+
+:is(.bg-danger, .bg-info) .navbar-nav .nav-link:focus, :is(.bg-danger, .bg-info) .navbar-nav .nav-link:hover {
+    color: hsla(0, 0%, 0%, 0.75)
 }
 
 .navbar-dark .navbar-nav .nav-link.disabled {
     color: hsla(0, 0%, 18%, .25)
 }
 
+.bg-dark .navbar-nav .nav-link.disabled {
+    color: hsla(0, 0%, 81%, 0.25)
+}
+
+:is(.bg-danger, .bg-info) .navbar-nav .nav-link.disabled {
+    color: hsla(0, 0%, 0%, 0.25)
+}
+
 .navbar-dark .navbar-nav .active > .nav-link, .navbar-dark .navbar-nav .nav-link.active, .navbar-dark .navbar-nav .nav-link.show, .navbar-dark .navbar-nav .show > .nav-link {
     color: #2e2e2e
+}
+
+.bg-dark .navbar-nav .active > .nav-link, .bg-dark .navbar-nav .nav-link.active, .bg-dark .navbar-nav .nav-link.show, .bg-dark .navbar-nav .show > .nav-link {
+    color: #c8c8c8
+}
+
+:is(.bg-danger, .bg-info) .navbar-nav .active > .nav-link, :is(.bg-danger, .bg-info) .navbar-nav .nav-link.active, :is(.bg-danger, .bg-info) .navbar-nav .nav-link.show, *:is(.bg-danger, .bg-info) .navbar-nav .show > .nav-link {
+    color: #000
 }
 
 .navbar-dark .navbar-toggler {


### PR DESCRIPTION
Fixes #2367 

### Before
![TandoorDarkOld](https://github.com/TandoorRecipes/recipes/assets/55469793/95f3b0cc-fff0-4c1e-ba2c-1fc9a00b2a57)
![TandoorDangerOld](https://github.com/TandoorRecipes/recipes/assets/55469793/895d177c-b878-4e52-b380-6690415c27af)
![TandoorInfoOld](https://github.com/TandoorRecipes/recipes/assets/55469793/11ad19e7-780b-4024-b211-6903700f9c77)

### After
![TandoorDarkNew](https://github.com/TandoorRecipes/recipes/assets/55469793/3a63847c-0cd4-4243-9c59-adc10ce378b2)
![TandoorDangerNew](https://github.com/TandoorRecipes/recipes/assets/55469793/5c49df8a-13a2-4c85-b584-f35970a2f6a7)
![TandoorInfoNew](https://github.com/TandoorRecipes/recipes/assets/55469793/a010597b-d019-4674-8178-ece85354e701)

### Explanation of Changes

```.bg-dark``` is a class attribute only present when the Dark Navigation Color is selected and will apply white to the text of the navigation bar.

```.bg-danger``` and ```.bg-info``` are class attributes only present when the Danger and Info Navigation Color are selected, respectively. ```:is(.bg-danger, .bg-info)``` selects any element with the class ```bg-danger``` or ```bg-info```, and applies a sharper black to the text of the navigation bar.

I'm open to feedback on the text color choices or the CSS class selectors used.