### PR TITLE
Updated nginx documentation to include image server instructions

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -204,6 +204,22 @@ server {
 }
 ```
 
+Tandoor does not support directly serving of images, as explained in the [Nginx vs Gunicorn"](#nginx-vs-gunicorn) section.  If you are already using nginx to serve as a reverse proxy, you can configure it to serve images as well.
+
+Add the following directly after the `location /` context:
+
+```
+        location /media/ {
+            root   /media/;
+            index  index.html index.htm;
+        }
+```
+
+Make sure you also update your `docker-compose.yml` file to mount the `mediafiles` directory.  If you are using the [Plain](#plain) deployment, you do not need to make any changes.  If you are using nginx to act as a reverse proxy for other apps, it may not be optimal to have `mediafiles` mounted to `/media`.  In that case, adjust the directory declarations as needed, utilizing nginx's [`alias`](https://nginx.org/en/docs/http/ngx_http_core_module.html#alias) if needed.
+
+!!!note
+    Use `alias` if your mount point directory is not the same as the URL request path.  Tandoor media files are requested from `$http_host/media/recipes/xxx.jpg`.  This means if you are mounting to a directory that does **NOT** end in `./media`, you will need to use `alias`.
+
 !!!note
     Don't forget to [download and configure](#docker-compose) your ```.env``` file!
 


### PR DESCRIPTION
This PR provides additional information to serve tandoor images from an nginx reverse proxy by bind-mounting the `mediafiles` directory and then serving the images directly from the server, and resolves #2796 

Please feel free to make modifications to the documentation as needed to fit the style of the existing style.

Code/configuration released under AGPL.  I'm not sure how you all are releasing your documentation.  Let me know what license you need and happy to release it under those terms.