### PR TITLE
make images use non-root users

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,3 +29,5 @@ vue/babel.config*
 vue/package.json
 vue/tsconfig.json
 vue/src/utils/openapi
+postgresql
+mediafiles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
-FROM python:3.10-alpine3.18
+FROM python:3.10-alpine3.18 as base
 
-#Install all dependencies.
+# Builder Stage where anything can be installed ignoring possible image size increases
+# as we only copy selected files to the final image from here.
+FROM base as builder
+
+#Install build dependencies.
 RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev openldap git
 
 #Print all logs without buffering it.
 ENV PYTHONUNBUFFERED 1
 
-#This port will be used by gunicorn.
-EXPOSE 8080
 
 #Create app dir and install requirements.
 RUN mkdir /opt/recipes
@@ -19,22 +21,58 @@ RUN \
     if [ `apk --print-arch` = "armv7" ]; then \
     printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
     fi
-RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev openssl-dev libffi-dev cargo openldap-dev python3-dev && \
-    echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev openssl-dev libffi-dev cargo openldap-dev python3-dev
+
+RUN echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \
     python -m venv venv && \
     /opt/recipes/venv/bin/python -m pip install --upgrade pip && \
-    venv/bin/pip install wheel==0.37.1 && \
-    venv/bin/pip install setuptools_rust==1.1.2 && \
-    venv/bin/pip install -r requirements.txt --no-cache-dir &&\
-    apk --purge del .build-deps
+    venv/bin/pip install --no-cache-dir wheel==0.37.1 && \
+    venv/bin/pip install --no-cache-dir setuptools_rust==1.1.2 && \
+    venv/bin/pip install --no-cache-dir -r requirements.txt
 
-#Copy project and execute it.
+# Optimize VENV Size
+# Delete unneded boto3 files as we only use the s3 functionality: (around 80MB, see https://github.com/boto/botocore/issues/1543)
+RUN cd venv/lib/python3.10/site-packages/botocore/data/ && ls  | grep -vw "s3" | xargs rm -r
+# Packages should be split into dev and production to not have the need to uninstall them again here:
+RUN venv/bin/pip uninstall -y faker pytest
+# Removing package files which are not needed for running them
+RUN find . | grep -E "(/wheel$|/setuptools$|/pip$|/__pycache__$|\.pyc$|\.pyo$|\.distinfo$|\.egg-info$)" | xargs rm -rf
+
+
 COPY . ./
 
 # collect information from git repositories
 RUN /opt/recipes/venv/bin/python version.py
-# delete git repositories to reduce image size
-RUN find . -type d -name ".git" | xargs rm -rf
+# Final image, everything in here will increase the size of image
+FROM base
 
+#Print all logs without buffering it.
+ENV PYTHONUNBUFFERED 1
+
+#This port will be used by gunicorn.
+EXPOSE 8080
+
+RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev openldap
+
+RUN mkdir /opt/recipes
+WORKDIR /opt/recipes
+
+RUN adduser -D --uid 1000 tandoor
+RUN chown -R 1000:1000 /opt/recipes
+
+COPY --chown=1000 ./boot.sh ./boot.sh
 RUN chmod +x boot.sh
+
+COPY --chown=1000 --from=builder /opt/recipes/venv/ /opt/recipes/venv/
+# Add Updated file with version information
+COPY --chown=1000 --from=builder /opt/recipes/manage.py /opt/recipes/manage.py
+
+# Explicity copy project files. (to ignore .git files used in the previous build step)
+COPY --chown=1000 ./recipes/ ./recipes/
+COPY --chown=1000 ./cookbook/ ./cookbook/
+
+USER tandoor
+
+
+# Execute
 ENTRYPOINT ["/opt/recipes/boot.sh"]

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,23 @@
+FROM nginx:mainline-alpine
+
+RUN rm -r /etc/nginx/conf.d/
+COPY ./nginx/conf.d/ /etc/nginx/conf.d/
+
+# TODO: Should we copy the staticfiles here? (This would make the additional /staticfiles mount uncessesary)
+
+RUN mkdir -p /var/cache/nginx/client_temp && \
+        mkdir -p /var/cache/nginx/proxy_temp && \
+        mkdir -p /var/cache/nginx/fastcgi_temp && \
+        mkdir -p /var/cache/nginx/uwsgi_temp && \
+        mkdir -p /var/cache/nginx/scgi_temp && \
+        chown -R nginx:nginx /var/cache/nginx && \
+        chown -R nginx:nginx /etc/nginx/ && \
+        chmod -R 755 /etc/nginx/ && \
+        chown -R nginx:nginx /var/log/nginx
+
+RUN touch /var/run/nginx.pid && \
+        chown -R nginx:nginx /var/run/nginx.pid /run/nginx.pid
+
+USER nginx
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
+# Just here as an example should be delete before merging this PR
 version: "3"
 services:
-  # Set rights for the bind-mount
   db_recipes-init:
     image: postgres:15-alpine
     volumes:
@@ -23,9 +23,8 @@ services:
     env_file:
       - ./.env
 
-  # Set rights for the bind-mounts
   web_recipes-init:
-    image: vabene1111/recipes
+    image: postgres:15-alpine
     volumes:
       - staticfiles:/staticfiles
       - ./mediafiles:/mediafiles
@@ -41,17 +40,26 @@ services:
       - web_recipes-init
       - db_recipes
     restart: always
-    image: vabene1111/recipes
+    # image: vabene1111/recipes
+    build:
+      context: .
+      dockerfile: Dockerfile
     env_file:
       - ./.env
     volumes:
       - staticfiles:/opt/recipes/staticfiles
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
+      # - nginx_config:/opt/recipes/nginx/conf.d
       - ./mediafiles:/opt/recipes/mediafiles
 
   nginx_recipes:
-    image: ghcr.io/TandoorRecipes/recipes-nginx
+    # image: nginx:mainline-alpine
+    build:
+      context: .
+      dockerfile: Dockerfile.nginx
     restart: always
-    user: 101:101
+    # To test its non running as root:
+    # user: 101:101
     ports:
       - 8080:8080
     env_file:
@@ -59,6 +67,8 @@ services:
     depends_on:
       - web_recipes
     volumes:
+      # Do not make this a bind mount, see https://docs.tandoor.dev/install/docker/#volumes-vs-bind-mounts
+      # - nginx_config:/etc/nginx/conf.d:ro
       - staticfiles:/static:ro
       - ./mediafiles:/media:ro
 

--- a/nginx/conf.d/Recipes.conf
+++ b/nginx/conf.d/Recipes.conf
@@ -1,5 +1,6 @@
 server {
-  listen 80;
+  # Needed as non-root user can't user ports below 1024
+  listen 8080;
   server_name localhost;
 
   client_max_body_size 128M;


### PR DESCRIPTION
fixes https://github.com/TandoorRecipes/recipes/issues/1257

also optimized image size of the "recipes" image from 365 MB to 202 MB

Open Questions: 
- [ ] Where do you want the image published to? So I can modify the workflow file. (In my mind maybe only to ghcr.io? This way any fork can also test the workflows) 
- [ ] How should the static files be handled? Now that there is an extra image we could also include them directly in the NGINX image. 

TODOs:
- [ ] Delete root docker-compose.yml