### PR TITLE
Fix next/prev week on mobile meal plan

### DIFF
--- a/vue/src/apps/MealPlanView/MealPlanView.vue
+++ b/vue/src/apps/MealPlanView/MealPlanView.vue
@@ -364,7 +364,7 @@ export default {
         },
         mobileSimpleGrid() {
             let grid = [];
-            let currentDate = moment();
+            let currentDate = moment(this.showDate);
             for (let x = 0; x < 7; x++) {
                 let moment_date = currentDate.clone().add(x, "d");
                 grid.push({
@@ -483,7 +483,7 @@ export default {
             this.setShowDate(ctx.selectedDate)
         },
         setShowDate(d) {
-            this.showDate = d
+            this.showDate = d ?? new Date();
         },
         createEntryClick(data) {
             this.mealplan_default_date = moment(data).format("YYYY-MM-DD")


### PR DESCRIPTION
Next/prev buttons on mobile for meal plan were not working (visibly). They were actually changing the calendar view which was hidden in the mobile sized viewport, but not the mobile list view. Below is a video of the fix


https://github.com/TandoorRecipes/recipes/assets/4297028/20615e11-8db2-4271-ad60-514b90ba9683

