### PR TITLE
docs: specify database and user role when running psql

### DIFF
--- a/docs/system/updating.md
+++ b/docs/system/updating.md
@@ -81,7 +81,7 @@ sudo mv -R ~/.docker/compose/postgres ~/.docker/compose/postgres.old
   ```
   8. Install postgres extensions
   ``` bash
-  docker exec -it {{database_container}} psql
+  docker exec -it {{database_container}} psql postgres -U {{djangouser}}
   ```
   then
   ``` psql


### PR DESCRIPTION
During the steps to re-import a PostgreSQL dump, the tool `psql` is used twice.

On first usage, the database and user role are specified: https://github.com/TandoorRecipes/recipes/blob/5129ef77c96fb27e08067f72600f3f4a0a76c6c5/docs/system/updating.md?plain=1#L80

At the second time, `psql` is run without any arguments: https://github.com/TandoorRecipes/recipes/blob/5129ef77c96fb27e08067f72600f3f4a0a76c6c5/docs/system/updating.md?plain=1#L84

This gave me the following error:

```console
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: FATAL:  role "root" does not exist
```

If I am not wrong, we should specify the database and user role here, as well. This is fixed by this merge request:

```shell
docker exec -it {{database_container}} psql postgres -U {{djangouser}}
```

---

Edit: I noticed this during my upgrade from `postgres:11-alpine` to `postgres:16-alpine`