### PR TITLE
Fix description overflow

### DIFF
--- a/vue/src/components/Buttons/RecipeSwitcher.vue
+++ b/vue/src/components/Buttons/RecipeSwitcher.vue
@@ -231,7 +231,7 @@ export default {
         font-size: 1.25rem;
         line-height: 1;
         background-color: transparent;
-        border: 1px solid rgba(46, 46, 46, 0.5);
+        border: 1px solid rgba(46, 46, 46, 0.1);
         border-radius: 0.1875rem;
         z-index: 1001;
     }

--- a/vue/src/components/RecipeCard.vue
+++ b/vue/src/components/RecipeCard.vue
@@ -257,10 +257,10 @@ export default {
 .content-details {
     position: absolute;
     text-align: center;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding: 1em 1em 0 1em;
     width: 100%;
-    height: 100%;
+    max-height: 100%;
+    overflow-y: scroll;
     top: 50%;
     left: 50%;
     opacity: 0;
@@ -289,10 +289,6 @@ export default {
 .content-details p {
     color: #fff;
     font-size: 0.8em;
-    height: 100%;
-    overflow-y: scroll;
-    padding-top: 1em;
-    padding-bottom: 1em;
 }
 
 .fadeIn-bottom {

--- a/vue/src/components/RecipeCard.vue
+++ b/vue/src/components/RecipeCard.vue
@@ -260,6 +260,7 @@ export default {
     padding-left: 1em;
     padding-right: 1em;
     width: 100%;
+    height: 100%;
     top: 50%;
     left: 50%;
     opacity: 0;
@@ -288,6 +289,10 @@ export default {
 .content-details p {
     color: #fff;
     font-size: 0.8em;
+    height: 100%;
+    overflow-y: scroll;
+    padding-top: 1em;
+    padding-bottom: 1em;
 }
 
 .fadeIn-bottom {


### PR DESCRIPTION
Partially solves #2520 by adding scroll to long descriptions:

![scroll](https://github.com/TandoorRecipes/recipes/assets/7606307/54631843-9521-4cc4-a761-e085ed71e178)

Bonus: match the border color of the quick action button aka recipe switcher on mobile with the hamburger menu button's border.

![IMG_9189](https://github.com/TandoorRecipes/recipes/assets/7606307/220bfebf-23e6-4d9c-8a6a-5829521b8467)
