### PR TITLE
doc: Add installation instructions for ArchLinux

### DIFF
--- a/docs/install/archlinux.md
+++ b/docs/install/archlinux.md
@@ -1,0 +1,48 @@
+These are instructions for pacman based distributions, like ArchLinux. The package is available from the [AUR](https://aur.archlinux.org/packages/tandoor-recipes-git) or from [GitHub](https://github.com/jdecourval/tandoor-recipes-pkgbuild).
+
+## Features
+- systemd integration.
+- Provide configuration for Nginx.
+- Use socket activation.
+- Use a non-root user.
+- Apply migrations automatically.
+
+## Installation
+1. Clone the package, build and install with makepkg:
+```shell
+git clone https://aur.archlinux.org/tandoor-recipes-git.git
+cd tandoor-recipes-git
+makepkg -si
+```
+or use your favourite AUR helper.
+
+2. Setup a PostgreSQL database and user, as explained here: https://docs.tandoor.dev/install/manual/#setup-postgresql
+
+3. Configure the service in `/etc/tandoor/tandoor.conf`.
+
+4. Reinstall the package, or follow [the official instructions](https://docs.tandoor.dev/install/manual/#initialize-the-application) to have tandoor creates its DB tables.
+
+5. Optionally configure a reverse proxy. A configuration for Nginx is provided, but you can Traefik, Apache, etc..
+Edit `/etc/nginx/sites-available/tandoor.conf`. You may want to use another `server_name`, or configure TLS. Then:
+```shell
+cd /etc/nginx/sites-enabled
+ln -s ../sites-available/tandoor.conf
+systemctl restart nginx
+```
+
+6. Enable the service
+```shell
+systemctl enable --now tandoor
+```
+
+## Upgrade
+```shell
+cd tandoor-recipes-git
+git pull
+makepkg -sif
+```
+Or use your favourite AUR helper.
+You shouldn't need to do anything else. This package applies migration automatically. If PostgreSQL has been updated to a new major version, you may need to [run pg_upgrade](https://wiki.archlinux.org/title/PostgreSQL#pg_upgrade).
+
+## Help
+This package is non-official. Issues should be posted to https://github.com/jdecourval/tandoor-recipes-pkgbuild or https://aur.archlinux.org/packages/tandoor-recipes-git.

--- a/docs/install/archlinux.md
+++ b/docs/install/archlinux.md
@@ -1,3 +1,6 @@
+!!! info "Community Contributed"
+    This guide was contributed by the community and is neither officially supported, nor updated or tested.
+
 These are instructions for pacman based distributions, like ArchLinux. The package is available from the [AUR](https://aur.archlinux.org/packages/tandoor-recipes-git) or from [GitHub](https://github.com/jdecourval/tandoor-recipes-pkgbuild).
 
 ## Features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ nav:
       - KubeSail or PiBox: install/kubesail.md
       - TrueNAS Portainer: install/truenas_portainer.md
       - WSL: install/wsl.md
+      - ArchLinux: install/archlinux.md
       - Manual: install/manual.md
       - Other setups: install/other.md
   - Features:


### PR DESCRIPTION
Hi,

For my own needs, I created a PKGBUILD to install TandoorRecipes on my ArchLinux based server. I've been using the package for several months by now, and at least one other user tested it: https://aur.archlinux.org/packages/tandoor-recipes-git#comment-924573

On ArchLinux, this package results in something similar to the [manual instructions](https://docs.tandoor.dev/install/manual/), but is easier to use, and should be more robust, since pacman can track installed files.

Are you interested in linking to this PKGBUILD, or to have it fully merged to this repository? For now, I'm proposing a new documentation page, but the package's sources are still hosted both on the AUR, and on my GitHub.

Let me know what you think of this. I can update the doc, or the package, to your requirements.