### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.10-alpine3.18
+
+#Install all dependencies.
+RUN apk add --no-cache postgresql-libs postgresql-client gettext zlib libjpeg libwebp libxml2-dev libxslt-dev openldap git yarn
+
+#Print all logs without buffering it.
+ENV PYTHONUNBUFFERED 1
+
+#This port will be used by gunicorn.
+EXPOSE 8000
+
+#This port will be used by vue
+EXPOSE 8080
+
+#Install all python dependencies to the image
+COPY requirements.txt /tmp/pip-tmp/
+
+RUN \
+    if [ `apk --print-arch` = "armv7" ]; then \
+    printf "[global]\nextra-index-url=https://www.piwheels.org/simple\n" > /etc/pip.conf ; \
+    fi
+RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev openssl-dev libffi-dev cargo openldap-dev python3-dev && \
+    echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \
+    pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt && \
+    rm -rf /tmp/pip-tmp && \
+    apk --purge del .build-deps

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+// For format details, see https://aka.ms/devcontainer.json.
+{
+	"name": "Tandoor Dev Container",
+	"build": { "context": "..", "dockerfile": "Dockerfile" },
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [8000, 8080],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "pip3 install --user -r requirements.txt"
+
+	// Configure tool-specific properties.
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.debugpy",
+				"ms-python.python"
+			]
+		}
+	}
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@
 
 version: 2
 updates:
+  - package-ecosystem: "devcontainers"
+    directory: "/"
+    schedule:
+      interval: weekly
+
   - package-ecosystem: "pip"
     directory: "/"
     schedule:

--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ data/
 /docker-compose.override.yml
 vue/node_modules
 plugins
-.vscode/
 vetur.config.js
 cookbook/static/vue
 vue/webpack-stats.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "name": "Python Debugger: Django",
+        "type": "debugpy",
+        "request": "launch",
+        "program": "${workspaceFolder}/manage.py",
+        "args": ["runserver"],
+        "django": true,
+        "justMyCode": true
+      }
+    ]
+  }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,6 +4,7 @@
     // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
+      
       {
         "name": "Python Debugger: Django",
         "type": "debugpy",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "cookbook/tests"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,49 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Run Migrations",
+        "type": "shell",
+        "command": "python3 manage.py migrate",
+      },
+      {
+        "label": "Run Dev Server",
+        "type": "shell",
+        "dependsOn": ["Run Migrations"],
+        "command": "python3 manage.py runserver",
+      },
+      {
+        "label": "Yarn Install",
+        "type": "shell",
+        "command": "yarn install",
+        "options": {
+          "cwd": "${workspaceFolder}/vue"
+        }
+      },
+      {
+        "label": "Yarn Serve",
+        "type": "shell",
+        "command": "yarn serve",
+        "dependsOn": ["Yarn Install"],
+        "options": {
+          "cwd": "${workspaceFolder}/vue"
+        }
+      },
+      {
+        "label": "Yarn Build",
+        "type": "shell",
+        "command": "yarn build",
+        "dependsOn": ["Yarn Install"],
+        "options": {
+          "cwd": "${workspaceFolder}/vue"
+        },
+        "group": "build",
+      },
+      {
+        "label": "Pytest",
+        "type": "shell",
+        "command": "python3 -m pytest cookbook/tests",
+        "group": "test",
+      }
+    ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,6 +10,7 @@
         "label": "Collect Static Files",
         "type": "shell",
         "command": "python3 manage.py collectstatic",
+        "dependsOn": ["Yarn Build"],
       },
       {
         "label": "Run Dev Server",
@@ -45,10 +46,14 @@
         "group": "build",
       },
       {
-        "label": "Pytest",
+        "label": "Setup Tests",
+        "dependsOn": ["Run Migrations", "Collect Static Files"],
+      },
+      {
+        "label": "Run all pytests",
         "type": "shell",
         "command": "python3 -m pytest cookbook/tests",
-        "dependsOn": ["Run Migrations", "Collect Static Files"],
+        "dependsOn": ["Setup Tests"],
         "group": "test",
       }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -7,6 +7,11 @@
         "command": "python3 manage.py migrate",
       },
       {
+        "label": "Collect Static Files",
+        "type": "shell",
+        "command": "python3 manage.py collectstatic",
+      },
+      {
         "label": "Run Dev Server",
         "type": "shell",
         "dependsOn": ["Run Migrations"],
@@ -43,6 +48,7 @@
         "label": "Pytest",
         "type": "shell",
         "command": "python3 -m pytest cookbook/tests",
+        "dependsOn": ["Run Migrations", "Collect Static Files"],
         "group": "test",
       }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -15,7 +15,7 @@
       {
         "label": "Run Dev Server",
         "type": "shell",
-        "dependsOn": ["Run Migrations"],
+        "dependsOn": ["Run Migrations", "Yarn Build"],
         "command": "python3 manage.py runserver",
       },
       {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -55,6 +55,16 @@
         "command": "python3 -m pytest cookbook/tests",
         "dependsOn": ["Setup Tests"],
         "group": "test",
+      },
+      {
+        "label": "Setup Documentation Dependencies",
+        "type": "shell",
+        "command": "pip install mkdocs-material mkdocs-include-markdown-plugin",
+      },
+      {
+        "label": "Serve Documentation",
+        "type": "shell",
+        "command": "mkdocs serve",
       }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,9 +13,13 @@
         "dependsOn": ["Yarn Build"],
       },
       {
+        "label": "Setup Dev Server",
+        "dependsOn": ["Run Migrations", "Yarn Build"],
+      },
+      {
         "label": "Run Dev Server",
         "type": "shell",
-        "dependsOn": ["Run Migrations", "Yarn Build"],
+        "dependsOn": ["Setup Dev Server"],
         "command": "python3 manage.py runserver",
       },
       {
@@ -65,6 +69,7 @@
         "label": "Serve Documentation",
         "type": "shell",
         "command": "mkdocs serve",
+        "dependsOn": ["Setup Documentation Dependencies"],
       }
     ]
 }

--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -20,6 +20,7 @@ Below are some of the larger contributions made yet.
 - [murphy83] added support for IPv6 #1490
 - [TheHaf] added custom serving size component #1411
 - [lostlont] added LDAP support #960
+- [c0mputerguru] added devcontainers for ease of development
 
 ## Translations
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -28,6 +28,11 @@ be used by other editors as well.  Once the container is running, you can do thi
 dev server, run python tests, etc. by either using the VSCode tasks below, or manually running commands described in the individual
 technology sections below.
 
+In VSCode, simply check out the git repository, and then via the command palette, choose `Dev Containers: Reopen in container`.
+
+If you need to change python dependencies (requierments.txt) or OS packages, you will need to rebuild the container.  If you are
+changing OS package requirements, you will need to update both the main `Dockerfile` and the `.devcontainer/Dockerfile`.
+
 ### VSCode Tasks
 If you use VSCode, there are a number of tasks that are available.  Here are a few of the key ones:
 

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -22,6 +22,26 @@ If you want to contribute bug fixes or small tweaks then your pull requests are 
 !!! info
     The dev setup is a little messy as this application combines the best (at least in my opinion) of both Django and Vue.js.
 
+### Devcontainer Setup
+There is a [devcontainer](https://containers.dev) set up to ease development.  It is optimized for VSCode, but should be able to
+be used by other editors as well.  Once the container is running, you can do things like start a Django dev server, start a Vue.js
+dev server, run python tests, etc. by either using the VSCode tasks below, or manually running commands described in the individual
+technology sections below.
+
+#### VSCode Tasks
+If you use dev containers with VSCode, there are a number of tasks that are available.  Here are a few of the key ones:
+
+* `Setup Dev Server` - Runs all the prerequisite steps so that the dev server can be run inside VSCode.
+* `Setup Tests` - Runs all prerequisites so tests can be run inside VSCode.
+
+Once these are run, you should be able to run/debug a django server in VSCode as well as run/debug tests directly through VSCode.
+There are also a few other tasks specified in case you have specific development needs:
+
+* `Run Dev Server` - Runs a django development server not connected to VSCode.
+* `Run all pytests` - Runs all the pytests outside of VSCode.
+* `Yarn Serve` - Runs development Vue.js server not connected to VSCode.  Useful if you want to make Vue changes and see them in realtime.
+* `Serve Documentation` - Runs a documentation server.  Useful if you want to see how changes to documentation show up.
+
 ### Django
 This application is developed using the Django framework for Python. They have excellent 
 [documentation](https://www.djangoproject.com/start/) on how to get started, so I will only give you the basics here.

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -28,8 +28,8 @@ be used by other editors as well.  Once the container is running, you can do thi
 dev server, run python tests, etc. by either using the VSCode tasks below, or manually running commands described in the individual
 technology sections below.
 
-#### VSCode Tasks
-If you use dev containers with VSCode, there are a number of tasks that are available.  Here are a few of the key ones:
+### VSCode Tasks
+If you use VSCode, there are a number of tasks that are available.  Here are a few of the key ones:
 
 * `Setup Dev Server` - Runs all the prerequisite steps so that the dev server can be run inside VSCode.
 * `Setup Tests` - Runs all prerequisites so tests can be run inside VSCode.


### PR DESCRIPTION
So I started down the path of wanting to write test for #2978, but didn't want to deal with venvs and messing around with installing random dependencies on my machine.  I've used devcontainers in the past to simplify creation of a development environment, and figured this would be great to simplify the development environment for tandoor.