### PR TITLE
bug: Fix decimal.InvalidOperation on /system for some PG versions

### DIFF
--- a/cookbook/views/views.py
+++ b/cookbook/views/views.py
@@ -293,11 +293,10 @@ def system(request):
 
     if postgres:
         postgres_current = 16  # will need to be updated as PostgreSQL releases new major versions
-        from decimal import Decimal
 
         from django.db import connection
 
-        postgres_ver = Decimal(str(connection.pg_version).replace('00', '.'))
+        postgres_ver = divmod(connection.pg_version, 10000)
         if postgres_ver >= postgres_current:
             database_status = 'success'
             database_message = _('Everything is fine!')


### PR DESCRIPTION
### Description

In https://github.com/TandoorRecipes/recipes/pull/2730 the /system page was improved to warn the user if the version of Postgres they are using is out of date and should be updated. The current code attempts to determine the major versions by replacing `00` with `.` and then converting to a `Decimal`. Unfortunately, it appears the only value this method _does not_ work for are initial releases of major versions, like `16.0.0`.

For reference, either Postgres or the PsyCog driver represents the semver values but without the dots, so `16.0.0` becomes `1600000`.

This change removes the string replace and Decimal conversion in favor of using the [`divmod()` function](https://docs.python.org/3/library/functions.html#divmod). In this application it will return a tuple with the first element being the major version of Postgres. This is then used as before to compare against deprecated versions.

### Versions

#### Postgres

```
=# SELECT version();
                                              version
------------------------------------------------------------------------------------------------------
PostgreSQL 16.0 (Debian 16.0-1.pgdg120+1) on x86_64-pc-linux-gnu, compiled by gcc (Debian 12.2.0-14) 12.2.0, 64-bit
(1 row)
```

#### Tandoor

```
Tandoor (HEAD) - 1.5.14

commit a626bda1ab400efc2f6a5f9de3c307f857ea7026
Author: vabene1111 
Date:   Tue Mar 5 14:06:56 2024 +0100

    Merge branch 'develop'
```


### Reproduction

```python
>>> Decimal("160000".replace('00', '.'))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
>>> Decimal("160001".replace('00', '.'))
Decimal('16.01')
```

### Testing

Manually testing with the following values and confirmed the `/system` page displayed the info/warning/ok notices as expected.

```python
postgres_ver = divmod(160000, 10000)[0]
postgres_ver = divmod(160001, 10000)[0]
postgres_ver = divmod(150000, 10000)[0]
postgres_ver = divmod(140000, 10000)[0]
postgres_ver = divmod(120000, 10000)[0]
```