### PR TITLE
fix: rounding units

### DIFF
--- a/vue/src/components/PropertyViewComponent.vue
+++ b/vue/src/components/PropertyViewComponent.vue
@@ -67,7 +67,7 @@
                                 <i class="text-warning fas fa-exclamation-triangle"></i>
                             </template>
                             <template v-else>
-                                {{ f.value }} {{ selected_property.unit }}
+                                {{ roundDecimals(f.value) }} {{ selected_property.unit }}
                             </template>
                         </td>
                     </tr>


### PR DESCRIPTION
fix for issue #3091 
Function roundDecimals was not being called in PropertyViewComponent b-modal element so food properties were not being rounded to the specified number of decimals. 

Here is a side by side comparison of the bug before and after the fix, using the same numbers.

<img width="552" alt="Screenshot 2024-04-05 at 15 59 46" src="https://github.com/TandoorRecipes/recipes/assets/121966638/d0d47150-34e9-4445-bfc9-d4be2a21af14">

<img width="553" alt="Screenshot 2024-04-05 at 15 58 57" src="https://github.com/TandoorRecipes/recipes/assets/121966638/ab02dfb6-1a90-4d6d-8f6f-2e7619dff76e">
