### PR TITLE
removing pre-cached staticfiles from Docker & boot.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,12 +35,6 @@ RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-de
 #Copy project and execute it.
 COPY . ./
 
-# collect the static files
-RUN /opt/recipes/venv/bin/python manage.py collectstatic_js_reverse
-RUN /opt/recipes/venv/bin/python manage.py collectstatic --noinput
-# copy the collected static files to a different location, so they can be moved into a potentially mounted volume
-RUN mv /opt/recipes/staticfiles /opt/recipes/staticfiles-collect
-
 # collect information from git repositories
 RUN /opt/recipes/venv/bin/python version.py
 # delete git repositories to reduce image size

--- a/boot.sh
+++ b/boot.sh
@@ -67,25 +67,12 @@ echo "Migrating database"
 
 python manage.py migrate
 
-if [[ "${DOCKER}" == "true" ]]; then
-    if [[ -d "/opt/recipes/staticfiles-collect" ]]; then
-        echo "Copying cached static files from docker build"
+echo "Collecting static files, this may take a while..."
 
-        mkdir -p /opt/recipes/staticfiles
-        rm -rf /opt/recipes/staticfiles/*
-        mv /opt/recipes/staticfiles-collect/* /opt/recipes/staticfiles
-        rm -rf /opt/recipes/staticfiles-collect
-    else
-        echo "Static files are already up to date"
-    fi
-else
-    echo "Collecting static files, this may take a while..."
+python manage.py collectstatic_js_reverse
+python manage.py collectstatic --noinput
 
-    python manage.py collectstatic_js_reverse
-    python manage.py collectstatic --noinput
-
-    echo "Done"
-fi
+echo "Done"
 
 chmod -R 755 /opt/recipes/mediafiles
 


### PR DESCRIPTION
`collectstatic` and `collectstatic_js_reverse` both have dependencies on `.env` variables.  They can't be built independent of the environment they are going to run in.