### PR TITLE
Remove obsolete "version: 3" to eliminate warning message

### DIFF
--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db_recipes:
     restart: always


### PR DESCRIPTION
The "version: 3" entry is obsolete and throws a warning: 'version' is obsolete. AFAIK, there's no reason to keep it. There's a lengthy discussion of this issue in a different repo: https://github.com/jasonacox/Powerwall-Dashboard/issues/453

They got rid of "version" in that project. It seems like it should be removed here too.