### PR TITLE
Remove obsolete "version:" entry

### DIFF
--- a/docs/install/docker/ipv6_plain/docker-compose.yml
+++ b/docs/install/docker/ipv6_plain/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "2.4"
 services:
   db_recipes:
     restart: always


### PR DESCRIPTION
Per my other PR, "version" is obsolete and throws a warning.

*NOTE:* This PR shows two changes, one to the `config: subnet` entry. I have **no idea** why a change is showing to that entry. I did _not_ make any change, and I also can't see what the change is supposed to be. Maybe it has something to do with line endings? I have created this PR twice, hoping the second time to avoid the second change that is not a change. I couldn't do it. 