### PR TITLE
Delete obsolete "version" entry from last two compose.yml files

### DIFF
--- a/docs/install/docker/nginx-proxy/docker-compose.yml
+++ b/docs/install/docker/nginx-proxy/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db_recipes:
     restart: always

--- a/docs/install/docker/traefik-nginx/docker-compose.yml
+++ b/docs/install/docker/traefik-nginx/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
   db_recipes:
     restart: always


### PR DESCRIPTION
Per my other PR, the "version" entry in `compose.yml` is obsolete. This PR completes the updating of the remaining two of those files.

NOTE: Ignore the first commit, for "Merge pull request #1 from TandoorRecipes/develop." That was me bringing my fork up-to-date. I'm still learning Git, so I'm afraid my commits are a little sloppy. But you can see that the only real changes are to the `compose.yml` files.