### PR TITLE
Fix null-constrait errors in mealie import

### DIFF
--- a/cookbook/integration/mealie.py
+++ b/cookbook/integration/mealie.py
@@ -72,14 +72,14 @@ class Mealie(Integration):
             )
             recipe.steps.add(step)
 
-        if 'recipe_yield' in recipe_json:
+        if 'recipe_yield' in recipe_json and recipe_json['recipe_yield'] is not None:
             recipe.servings = parse_servings(recipe_json['recipe_yield'])
             recipe.servings_text = parse_servings_text(recipe_json['recipe_yield'])
 
         if 'total_time' in recipe_json and recipe_json['total_time'] is not None:
             recipe.working_time = parse_time(recipe_json['total_time'])
 
-        if 'org_url' in recipe_json:
+        if 'org_url' in recipe_json and recipe_json['org_url'] is not None:
             recipe.source_url = recipe_json['org_url']
 
         recipe.save()


### PR DESCRIPTION
Fix following error during mealie  import:

```
ERROR 
null value in column "servings" of relation "cookbook_recipe" violates not-null constraint
DETAIL:  Failing row contains (304, Bechamel-Sauce, , , null, 0, t, 2024-10-12 13:47:31.576329+00, 2024-10-12 13:47:31.599914+00, 1, null, , 0, null, null, null, für 0,5 Liter Soße, None, 1, '0':2C '5':3C 'fur':1C 'liter':4C 'soss':5C, 'bechamel':2A 'bechamel-sauc':1A 'sauc':3A, null, t, f).
```

The error is caused by `"recipe_yield": null` in the exported recipes.