### PR TITLE
Avoid off-by-one when scraping 'servings_text'

### DIFF
--- a/cookbook/helper/recipe_url_import.py
+++ b/cookbook/helper/recipe_url_import.py
@@ -389,7 +389,7 @@ def parse_servings_text(servings):
             servings = ''
     if isinstance(servings, list):
         try:
-            servings = parse_servings_text(servings[1])
+            servings = parse_servings_text(servings[0])
         except Exception:
             pass
     return str(servings)[:32]


### PR DESCRIPTION
This was showing something like `servings=4` and `servings_text="['4']"` for all recipes I imported. Use the *first* item in the list instead of the second-- my list only has one entry which threw an exception, dropped it, and stringified the list. This matches the behavior of `servings`.