### PR TITLE
Make postgres data durable across reboots

### DIFF
--- a/docs/install/truenas_portainer.md
+++ b/docs/install/truenas_portainer.md
@@ -83,7 +83,7 @@ services:
     restart: always
     image: postgres:16-alpine
     volumes:
-      - ./postgresql:/var/lib/postgresql/data
+      - pg_data:/var/lib/postgresql/data
     env_file:
       - stack.env
 
@@ -117,6 +117,7 @@ services:
 volumes:
   nginx_config:
   staticfiles:
+  pg_data:
 ```
 
 -Download the .env template from [HERE](https://raw.githubusercontent.com/vabene1111/recipes/develop/.env.template) and load this file by pressing the "Load Variables from .env File" button:


### PR DESCRIPTION
By storing it to a real volume, the pg_data will persist across reboots.