### PR TITLE
fix url for sub-path hosting

### DIFF
--- a/cookbook/static/themes/tandoor.min.css
+++ b/cookbook/static/themes/tandoor.min.css
@@ -4,7 +4,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_400.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -14,7 +14,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_400.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -24,7 +24,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_400.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -34,7 +34,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_500.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -44,7 +44,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_500.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -54,7 +54,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_500.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -64,7 +64,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_700.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -74,7 +74,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_700.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -84,7 +84,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_700.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 

--- a/cookbook/static/themes/tandoor_dark.min.css
+++ b/cookbook/static/themes/tandoor_dark.min.css
@@ -4,7 +4,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_400.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -14,7 +14,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_400.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -24,7 +24,7 @@
     font-style: normal;
     font-weight: 400;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_400.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_400.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -34,7 +34,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_500.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -44,7 +44,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_500.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -54,7 +54,7 @@
     font-style: normal;
     font-weight: 500;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_500.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_500.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 
@@ -64,7 +64,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_devanagari_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_devanagari_700.woff2) format('woff2');
     unicode-range: U+0900-097F, U+1CD0-1CF6, U+1CF8-1CF9, U+200C-200D, U+20A8, U+20B9, U+25CC, U+A830-A839, U+A8E0-A8FB;
 }
 
@@ -74,7 +74,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_ext_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_ext_700.woff2) format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
 
@@ -84,7 +84,7 @@
     font-style: normal;
     font-weight: 700;
     font-display: swap;
-    src: url(/static/webfonts/poppins_latin_700.woff2) format('woff2');
+    src: url(../webfonts/poppins_latin_700.woff2) format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
 

--- a/cookbook/templates/base.html
+++ b/cookbook/templates/base.html
@@ -82,7 +82,7 @@
 
     {% if not request.user.userpreference.left_handed %}
         {% if not request.user.is_authenticated or request.user.userpreference.nav_show_logo %}
-            <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}"
+            <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}/"
                aria-label="Tandoor">
                 <img class="brand-icon" src="{{ theme_values.nav_logo }}" alt="Logo">
             </a>
@@ -96,7 +96,7 @@
 
     {% if request.user.userpreference.left_handed %}
         {% if not  request.user.is_authenticated or request.user.userpreference.nav_show_logo %}
-            <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}"
+            <a class="navbar-brand p-0 me-2 justify-content-center" href="{% base_path request 'base' %}/"
                aria-label="Tandoor">
                 <img class="brand-icon" src="{{ theme_values.nav_logo }}" alt="Logo">
             </a>


### PR DESCRIPTION
1. Add a slash to the nav-bar index link: `http://xx.xx/xx` to `http://xx.xx/xx/`
2. Use relative path in tandoor.min.css and tandoor_dark.min.css.