### PR TITLE
Disable DEBUG and DEBUG_TOOLBAR by default

### DIFF
--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -27,8 +27,8 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # Get vars from .env files
 SECRET_KEY = os.getenv('SECRET_KEY') if os.getenv('SECRET_KEY') else 'INSECURE_STANDARD_KEY_SET_IN_ENV'
 
-DEBUG = bool(int(os.getenv('DEBUG', True)))
-DEBUG_TOOLBAR = bool(int(os.getenv('DEBUG_TOOLBAR', True)))
+DEBUG = bool(int(os.getenv('DEBUG', '0')))
+DEBUG_TOOLBAR = bool(int(os.getenv('DEBUG_TOOLBAR', '0')))
 
 LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
 


### PR DESCRIPTION
The [documentation](https://docs.tandoor.dev/system/configuration/#debug) states that the Django DEBUG mode is disabled by default, and rightly points out that it should not be left enabled in production. 

This change aligns the code with the documentation, ensuring that people who run the app with default .env file don't end up with an unsecure configuration.