### PR TITLE
Add support for Python 3.13

### DIFF
--- a/cookbook/integration/recettetek.py
+++ b/cookbook/integration/recettetek.py
@@ -1,4 +1,4 @@
-import imghdr
+import filetype
 import json
 import re
 from io import BytesIO
@@ -128,7 +128,7 @@ class RecetteTek(Integration):
                     url = file['originalPicture']
                     if validate_import_url(url):
                         response = requests.get(url)
-                        if imghdr.what(BytesIO(response.content)) is not None:
+                        if filetype.is_image(BytesIO(response.content)):
                             self.import_recipe_image(recipe, BytesIO(response.content), filetype=get_filetype(file['originalPicture']))
                         else:
                             raise Exception("Original image failed to download.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ gunicorn==22.0.0
 lxml==5.3.0
 Markdown==3.5.1
 Pillow==11.1.0
-psycopg2-binary==2.9.9
+psycopg2-binary==2.9.10
 python-dotenv==1.0.0
 requests==2.32.3
 six==1.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ pytubefix==8.12.0
 aiohttp==3.10.11
 inflection==0.5.1
 redis==5.2.1
+filetype==1.2.0
 
 # Development
 pytest==8.0.0


### PR DESCRIPTION
Building Tandoor Recipes with Python 3.13 currently fails. I'd suggest the following changes to add support for Python 3.13:

- bump `psycopg2` to 2.9.10 since 2.9.9 does not support Python 3.13 yet
- replace `imghdr` with `filetype` as `imghdr` got removed from Python 3.13 after deprecation