### PR TITLE
Add webp file as allowed file type

### DIFF
--- a/cookbook/helper/image_processing.py
+++ b/cookbook/helper/image_processing.py
@@ -38,7 +38,7 @@ def get_filetype(name):
 def is_file_type_allowed(filename, image_only=False):
     is_file_allowed = False
     allowed_file_types = ['.pdf','.docx', '.xlsx']
-    allowed_image_types = ['.png', '.jpg', '.jpeg', '.gif']
+    allowed_image_types = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
     check_list = allowed_image_types
     if not image_only:
         check_list += allowed_file_types


### PR DESCRIPTION
Fix #3573 

WebP is fully supported by Tandoor but the recent change that added restriction to file type removed the ability to upload webp files.