### PR TITLE
Remove maxEntries from image cache in sw.js

### DIFF
--- a/vue/src/sw.js
+++ b/vue/src/sw.js
@@ -36,12 +36,7 @@ setCatchHandler(({event}) => {
 registerRoute(
     ({request}) => request.destination === 'image',
     new CacheFirst({
-        cacheName: 'images',
-        plugins: [
-            new ExpirationPlugin({
-                maxEntries: 20,
-            }),
-        ],
+        cacheName: 'images'
     }),
 );
 


### PR DESCRIPTION
I believe the hardcoded 20 that was in there is dated, browsers nowdays should be smart enough to know how many images they can/cant cache.