### PR TITLE
feat: introduce STATIC_ROOT env var

### DIFF
--- a/docs/system/configuration.md
+++ b/docs/system/configuration.md
@@ -132,6 +132,13 @@ This can either be a relative path from the applications base path or the url of
 STATIC_URL=/static/
 ```
 
+#### Static root
+
+> default `<basedir>/staticfiles` - options `/some/other/media/path`.
+
+Where staticfiles should be stored on disk. The default location is a
+`staticfiles` subfolder at the root of the application directory.
+
 #### Media URL
 
 > default `/static/` - options: `/any/url/path/`, `https://any.domain.name/and/url/path`

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -43,7 +43,7 @@ JS_REVERSE_OUTPUT_PATH = os.path.join(BASE_DIR, "cookbook/static/django_js_rever
 JS_REVERSE_SCRIPT_PREFIX = os.getenv('JS_REVERSE_SCRIPT_PREFIX', SCRIPT_NAME)
 
 STATIC_URL = os.getenv('STATIC_URL', '/static/')
-STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
+STATIC_ROOT = os.getenv('STATIC_ROOT', os.path.join(BASE_DIR, "staticfiles"))
 
 # Get vars from .env files
 SECRET_KEY = os.getenv('SECRET_KEY', 'INSECURE_STANDARD_KEY_SET_IN_ENV')


### PR DESCRIPTION
You like the already existing `MEDIA_ROOT`

My usecase is to have both the media and staticfiles root outside of the `/opt/recipes/` directory to avoid `subPath` mounting on Kubernetes.

It felt missing since `MEDIA_URL` and `MEDIA_ROOT` exist but only `STATIC_URL`.