### PR TITLE
Fix missing VNumberInput import on advanced search page

### DIFF
--- a/vue3/src/pages/SearchPage.vue
+++ b/vue3/src/pages/SearchPage.vue
@@ -159,6 +159,7 @@ import {routeQueryDateTransformer, stringToBool, toNumberArray} from "@/utils/ut
 import RandomIcon from "@/components/display/RandomIcon.vue";
 import {VSelect, VTextField} from "vuetify/components";
 import RatingField from "@/components/inputs/RatingField.vue";
+import {VNumberInput} from 'vuetify/labs/VNumberInput';
 
 const {t} = useI18n()
 const router = useRouter()


### PR DESCRIPTION
See #3676 