### PR TITLE
fix: improved dark mode contrast for dropdowns in ShoppingListView

### DIFF
--- a/vue3/src/components/display/ShoppingListView.vue
+++ b/vue3/src/components/display/ShoppingListView.vue
@@ -378,5 +378,21 @@ function loadSupermarkets() {
 </script>
 
 <style scoped>
+/* Force dark mode styling for dropdowns */
+.theme-dark select,
+.theme-dark .dropdown,
+.theme-dark .v-select,
+.theme-dark .v-input,
+.theme-dark .v-menu__content {
+  background-color: #2b2b2b !important;
+  color: #f0f0f0 !important;
+  border: 1px solid #444;
+}
 
+/* Optional: hover and focus styling */
+.theme-dark select:focus,
+.theme-dark .v-select:focus {
+  outline: none;
+  border-color: #888;
+}
 </style>


### PR DESCRIPTION
This PR addresses issue #3836 by applying scoped dark-mode styles to dropdowns in `ShoppingListView.vue`.

✔️ Sets background to `#2b2b2b` and text to `#f0f0f0`  
✔️ Ensures visual consistency and accessibility in dark theme  
✔️ Targets Vuetify components (`v-select`, `v-input`, etc.) used in grocery list UI
