### PR TITLE
Fixed k8s setup for tandoor 2

### DIFF
--- a/docs/install/k8s/50-deployment.yaml
+++ b/docs/install/k8s/50-deployment.yaml
@@ -63,7 +63,6 @@ spec:
           source venv/bin/activate
           echo "Updating database"
           python manage.py migrate
-          python manage.py collectstatic_js_reverse
           python manage.py collectstatic --noinput
           echo "Setting media file attributes"
           chown -R 65534:65534 /opt/recipes/mediafiles


### PR DESCRIPTION
I'm running Tandoor in k8s with the default setup described in the documentation. As its not tested i noticed It didn't work after updating to tandoor 2. 

Checking the code the init container has the collectstatic_js_reverse command. The dependency that was needed was removed from the requirements.txt with the upgrade so it worked after removing the command in the init container. 