### PR TITLE
fix: remove python-ldap workaround, not needed anymore since openldap >3.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN \
 # remove Development dependencies from requirements.txt
 RUN sed -i '/# Development/,$d' requirements.txt
 RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-dev jpeg-dev libwebp-dev openssl-dev libffi-dev cargo openldap-dev python3-dev xmlsec-dev xmlsec build-base g++ curl && \
-    echo -n "INPUT ( libldap.so )" > /usr/lib/libldap_r.so && \
     python -m venv venv && \
     /opt/recipes/venv/bin/python -m pip install --upgrade pip && \
     venv/bin/pip debug -v && \


### PR DESCRIPTION
As seen in the releasenotes:
>This is a minor release to provide out-of-the-box compatibility with the merge
of libldap and libldap_r that happened with OpenLDAP's 2.5 release.

https://github.com/python-ldap/python-ldap/releases/tag/python-ldap-3.4.2

Tandoor is currently on 3.4.4 so this shouldn't be needed anymore. This is just based on the docs, please test this :)