### PR TITLE
fix(vite): Configure Vite to use subfolder

### DIFF
--- a/vue3/src/apps/tandoor/main.ts
+++ b/vue3/src/apps/tandoor/main.ts
@@ -63,8 +63,12 @@ TANDOOR_PLUGINS.forEach(plugin => {
     routes = routes.concat(plugin.routes)
 })
 
+const basePath = localStorage.getItem("BASE_PATH")
+const pathname = basePath?.startsWith("http") ? new URL(basePath).pathname : undefined
+const base = pathname === "/" ? undefined : pathname
+
 const router = createRouter({
-    history: createWebHistory(),
+    history: createWebHistory(base),
     routes,
 })
 

--- a/vue3/vite.config.ts
+++ b/vue3/vite.config.ts
@@ -7,7 +7,7 @@ import {VitePWA} from "vite-plugin-pwa";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-    base: '/static/vue3/',
+    base: './',
     plugins: [
         vue({
             template: {transformAssetUrls}


### PR DESCRIPTION
Fixes #3903 

In `vue3/vite.config.ts`, as recommended in the docs: https://vite.dev/guide/build.html#relative-base we use a relative path. I was able to confirm it was not introducing issues when building the app and serving it from the dev server.

Then for SPA navigation, we need to init the router with the base URL. This is done when instantiating the router, so we retrieve the base URL injected by the backend and extract the path if there's one, or defaulting to `undefined`, which is the default behaviour if there is none: https://router.vuejs.org/api/functions/createWebHistory.html#Function-createWebHistory-