### PR TITLE
Allow video file types to be uploaded

### DIFF
--- a/cookbook/helper/image_processing.py
+++ b/cookbook/helper/image_processing.py
@@ -37,7 +37,7 @@ def get_filetype(name):
 
 def is_file_type_allowed(filename, image_only=False):
     is_file_allowed = False
-    allowed_file_types = ['.pdf', '.docx', '.xlsx', '.css']
+    allowed_file_types = ['.pdf', '.docx', '.xlsx', '.css', '.mp4', '.mov']
     allowed_image_types = ['.png', '.jpg', '.jpeg', '.gif', '.webp']
     check_list = allowed_image_types
     if not image_only:


### PR DESCRIPTION
In the previous version of Tandoor I could upload some videos in the steps to document some specific process. Now this seems impossible.
Although I can still download the videos that were uploaded in the latest version.

This pull request adds two "file" types in the allowed list, .mp4 and .mov.