### PR TITLE
Update nginx configuration for manual setup

### DIFF
--- a/docs/install/manual.md
+++ b/docs/install/manual.md
@@ -196,6 +196,7 @@ server {
         proxy_set_header Host $http_host;
         proxy_pass http://unix:/var/www/recipes/recipes.sock;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-For $remote_addr;
     }
 }
 ```


### PR DESCRIPTION
Since v2 tandoor added user session tracking which requires the reverse proxy to add an extra header.

This change adds the `X-Forwarded-For` header to the example nginx configuration. This header fixes the issue described in #3943.