### PR TITLE
refactor: move staticfiles collection from runtime to build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,9 @@ COPY . ./
 RUN rm -rf /etc/nginx/http.d && \
     ln -s /opt/recipes/http.d /etc/nginx/http.d && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
-    ln -sf /dev/stderr /var/log/nginx/error.log
+    ln -sf /dev/stderr /var/log/nginx/error.log && \
+    # collect staticfiles
+    venv/bin/python manage.py collectstatic --noinput
 
 # commented for now https://github.com/TandoorRecipes/recipes/issues/3478
 #HEALTHCHECK --interval=30s \

--- a/boot.sh
+++ b/boot.sh
@@ -4,7 +4,6 @@ source venv/bin/activate
 # these are envsubst in the nginx config, make sure they default to something sensible when unset
 export TANDOOR_PORT="${TANDOOR_PORT:-8080}"
 export MEDIA_ROOT=${MEDIA_ROOT:-/opt/recipes/mediafiles};
-export STATIC_ROOT=${STATIC_ROOT:-/opt/recipes/staticfiles};
 
 GUNICORN_WORKERS="${GUNICORN_WORKERS:-3}"
 GUNICORN_THREADS="${GUNICORN_THREADS:-2}"
@@ -91,18 +90,12 @@ if [ "${PLUGINS_BUILD}" -eq 1 ]; then
     python plugin.py
 fi
 
-echo "Collecting static files, this may take a while..."
-
-python manage.py collectstatic --noinput
-
-echo "Done"
-
 chmod -R 755 ${MEDIA_ROOT:-/opt/recipes/mediafiles}
 
 ipv6_disable=$(cat /sys/module/ipv6/parameters/disable)
 
 # prepare nginx config
-envsubst '$MEDIA_ROOT $STATIC_ROOT $TANDOOR_PORT' < /opt/recipes/http.d/Recipes.conf.template > /opt/recipes/http.d/Recipes.conf
+envsubst '$MEDIA_ROOT $TANDOOR_PORT' < /opt/recipes/http.d/Recipes.conf.template > /opt/recipes/http.d/Recipes.conf
 
 # start nginx
 echo "Starting nginx"

--- a/http.d/Recipes.conf.template
+++ b/http.d/Recipes.conf.template
@@ -13,7 +13,7 @@ server {
 
   # serve service worker under main path
   location = /service-worker.js {
-    alias ${STATIC_ROOT}/vue3/service-worker.js;
+    alias /opt/recipes/staticfiles/vue3/service-worker.js;
   }
 
   # pass requests for dynamic content to gunicorn

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -42,7 +42,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCRIPT_NAME = os.getenv('SCRIPT_NAME', '')
 
 STATIC_URL = os.getenv('STATIC_URL', '/static/')
-STATIC_ROOT = os.getenv('STATIC_ROOT', os.path.join(BASE_DIR, "staticfiles"))
+STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
 
 # Get vars from .env files
 SECRET_KEY = os.getenv('SECRET_KEY', 'INSECURE_STANDARD_KEY_SET_IN_ENV')


### PR DESCRIPTION
This will remove the `STATIC_ROOT` env var, I will update the documentation accordingly after this is merged.

I personally don't see any problems doing this, it is now guaranteed that each user runs exactly the same setup since it build into the container.

What was the reason that this collection existed on runtime instead of buildtime?