### PR TITLE
feat: make it possible to switch to a non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,12 +30,16 @@ RUN apk add --no-cache --virtual .build-deps gcc musl-dev postgresql-dev zlib-de
 #Copy project and execute it.
 COPY . ./
 
-# delete default nginx config and link it to tandoors config
-# create symlinks to access and error log to show them on stdout
-RUN rm -rf /etc/nginx/http.d && \
-    ln -s /opt/recipes/http.d /etc/nginx/http.d && \
-    ln -sf /dev/stdout /var/log/nginx/access.log && \
+RUN <<EOF
+    # delete default nginx config and link it to tandoors config
+    rm -rf /etc/nginx/http.d
+    ln -s /opt/recipes/http.d /etc/nginx/http.d
+    # allow all write/read but set sticky bit to restrict non-root to only create files (conf templating in boot.sh)
+    chmod 1777 /opt/recipes/http.d/
+    # create symlinks to access and error log to show them on stdout
+    ln -sf /dev/stdout /var/log/nginx/access.log
     ln -sf /dev/stderr /var/log/nginx/error.log
+EOF
 
 # commented for now https://github.com/TandoorRecipes/recipes/issues/3478
 #HEALTHCHECK --interval=30s \

--- a/http.d/Recipes.conf.template
+++ b/http.d/Recipes.conf.template
@@ -1,3 +1,10 @@
+# set paths to writable location as non-root by default
+proxy_temp_path /tmp/proxy_temp;
+client_body_temp_path /tmp/client_temp;
+fastcgi_temp_path /tmp/fastcgi_temp;
+uwsgi_temp_path /tmp/uwsgi_temp;
+scgi_temp_path /tmp/scgi_temp;
+
 server {
   listen ${TANDOOR_PORT};
   listen [::]:${TANDOOR_PORT} ipv6only=on;
@@ -19,7 +26,7 @@ server {
   # pass requests for dynamic content to gunicorn
   location / {
     proxy_set_header Host $http_host;
-    proxy_pass http://unix:/run/tandoor.sock;
+    proxy_pass http://unix:/tmp/tandoor.sock;
 
     # param needed by django allauth sessions to log IP
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
These changes make it possible to start the container as a non-root user. The only prerequisite is an external database since the non-root user can't create the `db.sqlite3` in the projectroot anymore (this can be fixed by changing the path, if needed I can expose this as en env var).

None of these changes should impact existing users (or new for that matter) since the image itself doesn't change user and it rootful still. We can't really move away from that easily since the users will need to chown all the mediafiles to be owned by the user.

However these changes will give users the option to switch to a non-root user :)