### PR TITLE
Provide stable ordering of shopping list entries for pagination

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1963,6 +1963,8 @@ class ShoppingListEntryViewSet(LoggingMixin, viewsets.ModelViewSet):
                                                                                                'list_recipe__mealplan__recipe',
                                                                                                ).distinct().all()
 
+        self.queryset = self.queryset.order_by('id')
+
         updated_after = self.request.query_params.get('updated_after', None)
         mealplan = self.request.query_params.get('mealplan', None)
 


### PR DESCRIPTION
Pagination without a stable ordering can result in missed entries if the order loaded for each page request is different.  I believe this was causing missed entries in the shopping list. 

See #4084 for more information.