### PR TITLE
Requests using date should be in local timezone, not UTC as tandoor is timezone aware

### DIFF
--- a/cookbook/tests/api/test_api_meal_plan.py
+++ b/cookbook/tests/api/test_api_meal_plan.py
@@ -99,19 +99,19 @@ def test_list_filter(obj_1, u1_s1):
 
     response = json.loads(
         u1_s1.get(
-            f'{reverse(LIST_URL)}?from_date={(timezone.now() + timedelta(days=2)).strftime("%Y-%m-%d")}'
+            f'{reverse(LIST_URL)}?from_date={(timezone.localtime(timezone.now()) + timedelta(days=1)).strftime("%Y-%m-%d")}'
         ).content)['results']
     assert len(response) == 0
 
     response = json.loads(
         u1_s1.get(
-            f'{reverse(LIST_URL)}?to_date={(timezone.now() - timedelta(days=2)).strftime("%Y-%m-%d")}'
+            f'{reverse(LIST_URL)}?to_date={(timezone.localtime(timezone.now()) - timedelta(days=1)).strftime("%Y-%m-%d")}'
         ).content)['results']
     assert len(response) == 0
 
     response = json.loads(
         u1_s1.get(
-            f'{reverse(LIST_URL)}?from_date={(timezone.now() - timedelta(days=2)).strftime("%Y-%m-%d")}&to_date={(timezone.now() + timedelta(days=2)).strftime("%Y-%m-%d")}'
+            f'{reverse(LIST_URL)}?from_date={(timezone.localtime(timezone.now()) - timedelta(days=1)).strftime("%Y-%m-%d")}&to_date={(timezone.localtime(timezone.now()) + timedelta(days=1)).strftime("%Y-%m-%d")}'
         ).content)['results']
     assert len(response) == 1
 
@@ -153,8 +153,8 @@ def test_add(arg, request, u1_s2, recipe_1_s1, meal_type):
             'id': meal_type.id,
             'name': meal_type.name
         },
-        'from_date': (timezone.now()).strftime("%Y-%m-%d"),
-        'to_date': (timezone.now()).strftime("%Y-%m-%d"),
+        'from_date': (timezone.localtime(timezone.now())).strftime("%Y-%m-%d"),
+        'to_date': (timezone.localtime(timezone.now())).strftime("%Y-%m-%d"),
         'servings': 1,
         'title': 'test',
         'shared': []
@@ -196,8 +196,8 @@ def test_add_with_shopping(u1_s1, meal_type):
             'id': meal_type.id,
             'name': meal_type.name
         },
-        'from_date': (timezone.now()).strftime("%Y-%m-%d"),
-        'to_date': (timezone.now()).strftime("%Y-%m-%d"),
+        'from_date': (timezone.localtime(timezone.now())).strftime("%Y-%m-%d"),
+        'to_date': (timezone.localtime(timezone.now())).strftime("%Y-%m-%d"),
         'servings': 1,
         'title': 'test',
         'shared': [],
@@ -212,13 +212,13 @@ def test_add_with_shopping(u1_s1, meal_type):
 
 @pytest.mark.parametrize("arg", [
     ['', 2],
-    [f'?from_date={timezone.now().strftime("%Y-%m-%d")}', 1],
+    [f'?from_date={timezone.localtime(timezone.now()).strftime("%Y-%m-%d")}', 1],
     [
-        f'?to_date={(timezone.now() - timedelta(days=1)).strftime("%Y-%m-%d")}',
+        f'?to_date={(timezone.localtime(timezone.now()) - timedelta(days=1)).strftime("%Y-%m-%d")}',
         1
     ],
     [
-        f'?from_date={(timezone.now() + timedelta(days=2)).strftime("%Y-%m-%d")}&to_date={(timezone.now() + timedelta(days=2)).strftime("%Y-%m-%d")}',
+        f'?from_date={(timezone.localtime(timezone.now()) + timedelta(days=1)).strftime("%Y-%m-%d")}&to_date={(timezone.localtime(timezone.now()) + timedelta(days=1)).strftime("%Y-%m-%d")}',
         0
     ],
 ])


### PR DESCRIPTION
Tests were passing in a date that was always in UTC, and then that date was being interpreted on the server as in the local timezone.  This was causing sporadic test failures; when the local timezone was a different day than UTC, the tests would fail because "today in UTC" was "yesterday in local", so finding meal plans that were "today in UTC" would not include the meal plan that was "today in local".

I verified this by locally setting the timezone to something very different (Sydney Australia).  Without using timezone.localtime(timezone.now()) the test would fail, but using it the tests now pass.

This test bug was found when proposing a fix for #4084