### PR TITLE
Use loopback in nginx to point to own backend instead of container name

### DIFF
--- a/nginx/conf.d/Recipes.conf
+++ b/nginx/conf.d/Recipes.conf
@@ -19,7 +19,7 @@ server {
   # pass requests for dynamic content to gunicorn
   location / {
     proxy_set_header Host $http_host;
-    proxy_pass http://web_recipes:8080;
+    proxy_pass http://127.0.0.1:8080;
     
     error_page 502 /errors/http502.html;
   }


### PR DESCRIPTION
Fixes tandoor not being available when container is not named exatcly `web_recipes`.

Fixes https://github.com/TandoorRecipes/recipes/issues/4117

