### PR TITLE
feat: show offline indicator (#621)

### DIFF
--- a/vue3/src/apps/tandoor/Tandoor.vue
+++ b/vue3/src/apps/tandoor/Tandoor.vue
@@ -15,6 +15,7 @@
 
             <v-spacer></v-spacer>
             <global-search-dialog></global-search-dialog>
+            <offline-status-icon class="me-2 d-print-none"></offline-status-icon>
             <v-btn icon="$add" class="d-print-none">
                 <v-icon icon="$add" class="fa-fw"></v-icon>
                 <v-menu activator="parent">
@@ -124,12 +125,15 @@
             location="top center"
         ></v-snackbar-queued>
 
-    </v-app>
+        <offline-indicator></offline-indicator>
+  </v-app>
 
 </template>
 
 <script lang="ts" setup>
 import GlobalSearchDialog from "@/components/inputs/GlobalSearchDialog.vue"
+import OfflineIndicator from "@/components/display/OfflineIndicator.vue"
+import OfflineStatusIcon from "@/components/display/OfflineStatusIcon.vue"
 
 import {useDisplay} from "vuetify"
 import VSnackbarQueued from "@/components/display/VSnackbarQueued.vue";

--- a/vue3/src/components/display/OfflineIndicator.vue
+++ b/vue3/src/components/display/OfflineIndicator.vue
@@ -1,0 +1,26 @@
+<template>
+  <v-snackbar v-model="showBanner" :timeout="5000" location="top" color="warning" multi-line>
+    <div class="d-flex align-center">
+      <v-icon icon="fa-solid fa-triangle-exclamation" class="me-2"></v-icon>
+      <span>{{ $t("OfflineMode") }}</span>
+    </div>
+    <template v-slot:actions>
+      <v-btn variant="text" @click="showBanner = false" size="small">
+        {{ $t("Close") }}
+      </v-btn>
+    </template>
+  </v-snackbar>
+</template>
+
+<script lang="ts" setup>
+import { ref, watch } from "vue"
+import { useOfflineDetection } from "@/composables/useOfflineDetection"
+
+const { isOnline } = useOfflineDetection()
+
+const showBanner = ref(false)
+
+watch(isOnline, (online) => {
+  showBanner.value = !online
+})
+</script>

--- a/vue3/src/components/display/OfflineStatusIcon.vue
+++ b/vue3/src/components/display/OfflineStatusIcon.vue
@@ -1,0 +1,29 @@
+<template>
+  <v-tooltip v-if="!isOnline" :text="$t('OfflineMode')" location="bottom">
+    <template v-slot:activator="{ props }">
+      <v-icon v-bind="props" icon="fa-solid fa-triangle-exclamation" color="error" class="pulse-animation" size="small"></v-icon>
+    </template>
+  </v-tooltip>
+</template>
+
+<script lang="ts" setup>
+import { useOfflineDetection } from "@/composables/useOfflineDetection"
+
+const { isOnline } = useOfflineDetection()
+</script>
+
+<style scoped>
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
+}
+
+.pulse-animation {
+  animation: pulse 2s ease-in-out infinite;
+}
+</style>

--- a/vue3/src/composables/useOfflineDetection.ts
+++ b/vue3/src/composables/useOfflineDetection.ts
@@ -1,0 +1,27 @@
+import { ref, onMounted, onUnmounted } from "vue"
+
+const isOnline = ref(typeof navigator !== "undefined" ? navigator.onLine : true)
+
+export function useOfflineDetection() {
+  const handleOnline = () => {
+    isOnline.value = true
+  }
+
+  const handleOffline = () => {
+    isOnline.value = false
+  }
+
+  onMounted(() => {
+    window.addEventListener("online", handleOnline)
+    window.addEventListener("offline", handleOffline)
+  })
+
+  onUnmounted(() => {
+    window.removeEventListener("online", handleOnline)
+    window.removeEventListener("offline", handleOffline)
+  })
+
+  return {
+    isOnline,
+  }
+}

--- a/vue3/src/locales/en.json
+++ b/vue3/src/locales/en.json
@@ -383,6 +383,7 @@
   "NutritionsPerServing": "Nutritions per Serving",
   "NutritionsPerServingHelp": "Some applications do not specify if nutritions are per recipe or per serving. By default Tandoor treats them as per recipe. Check this box to treat them as per serving. ",
   "OfflineAlert": "You are offline, shopping list may not syncronize.",
+  "OfflineMode": "You are offline",
   "Ok": "Ok",
   "OnHand": "Currently On Hand",
   "OnHand_help": "Food is in inventory and will not be automatically added to a shopping list.  Onhand status is shared with shopping users.",


### PR DESCRIPTION
- Added **OfflineIndicator** component that displays `v-snackbar` when the user goes offline
- Added **OfflineStatusIcon** component that shows an`v-icon` in the header when offline
- Created `useOfflineDetection` composable to track online/offline status
- Banner auto-dismisses after 5 seconds
- Icon pulses when offline for better visibility