### PR TITLE
Docs: Added trailing slash to `system` path

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ then make sure you have set [all required headers](install/docker.md#required-he
 If that doesn't fix it, you can also refer to the appropriate sub section in the [reverse proxy documentation](install/docker.md#reverse-proxy) and verify your general webserver configuration.
 
 ### Required Headers
-Navigate to `/system` and review the headers listed in the DEBUG section.  At a minimum, if you are using a reverse proxy the headers must match the below conditions.
+Navigate to `/system/` and review the headers listed in the DEBUG section.  At a minimum, if you are using a reverse proxy the headers must match the below conditions.
 
 | Header      | Requirement |
 | :---        |    :----   |


### PR DESCRIPTION
The documentation instructs to navigate to `/system`. However, without a trailing `/` the application will return a 404.

While on topic, it might be even better to change it to something like `<your-tandoor-url>/system/`.