### PR TITLE
Adding port to the docker_compose.yml

### DIFF
--- a/docs/install/docker/plain/docker-compose.yml
+++ b/docs/install/docker/plain/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: postgres:16-alpine
     volumes:
       - ./postgresql:/var/lib/postgresql/data
+    ports:
+       - 80:80
     env_file:
       - ./.env
 


### PR DESCRIPTION
Updating to include port in docker_compose.yml. Without this I do not think the docker container has a mechanism for displaying the webpage on the internal port.