### PR TITLE
Added Yarn install and Build commands to DockerFile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,15 @@ RUN rm -rf /etc/nginx/http.d && \
 #            --retries=3 \
 #            CMD [ "/usr/bin/wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8080/openapi" ]
 
+
+# collect and build Vue files using Yarn
+RUN npm install -g yarn
+WORKDIR /opt/recipes/vue3
+RUN yarn install
+RUN yarn build
+
+WORKDIR /opt/recipes
+
 # collect information from git repositories
 RUN /opt/recipes/venv/bin/python version.py
 # delete git repositories to reduce image size


### PR DESCRIPTION
Based on the info from this ["Django_vite Core Exception after Super user Sign-in " issue](https://github.com/TandoorRecipes/recipes/issues/4177). I have included the necessary npm install of yarn, then the yarn install and build commands to the docker file before the entry point. This solves the broken state of building from source without the github actions. I am not very familiar with github actions so let me know if it breaks your "Build Docker Container" action.