### PR TITLE
feat(share): add option to share files to PWA

### DIFF
--- a/cookbook/views/views.py
+++ b/cookbook/views/views.py
@@ -434,12 +434,18 @@ def web_manifest(request):
         }],
         "share_target": {
             "action": "/recipe/import",
-            "method": "GET",
-            "enctype": "application/x-www-form-urlencoded",
+            "method": "POST",
+            "enctype": "multipart/form-data",
             "params": {
                 "title": "title",
                 "url": "url",
-                "text": "text"
+                "text": "text",
+                "files": [
+                    {
+                        "name": "data",
+                        "accept": ["image/*", "text/plain", "application/pdf"]
+                    }
+                ]
             }
         }
     }

--- a/vue3/tsconfig.app.json
+++ b/vue3/tsconfig.app.json
@@ -6,6 +6,7 @@
     "composite": true,
     "verbatimModuleSyntax": false,
     "baseUrl": ".",
+    "lib": ["ES2020", "DOM", "DOM.Iterable", "webworker"], // extend to add webworker lib
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
* adjusts the `manifest.json` file to configure `files` option
* add service-worker handling to intercept the POST request, write the file to shared cache and redirect to the vue app
* adds handling in vue app to read the file from cache and preload the AI import view

This implements https://github.com/TandoorRecipes/recipes/issues/4220