### PR TITLE
Sort Recipe Property Ingredient Window

### DIFF
--- a/vue3/src/components/display/PropertyView.vue
+++ b/vue3/src/components/display/PropertyView.vue
@@ -39,8 +39,11 @@
         <v-card v-if="dialogProperty" :loading="loading">
             <v-closable-card-title :title="`${dialogProperty.propertyAmountTotal} ${dialogProperty.unit} ${dialogProperty.name}`" :sub-title="$t('total')" icon="$properties"
                                    v-model="dialog"></v-closable-card-title>
-            <v-btn @click="sortFoodValues" :variant="isSorted ? 'flat' : 'outlined'" color="primary" size="small" class="rounded-pill d-print-none px-3 align-self-start ms-2 text-body-2 text-medium-emphasis">
-                Sort Decreasing</v-btn>
+            <v-btn 
+                v-if="dialogProperty && !dialogProperty.missingValue"
+                @click="sortFoodValues" :variant="isSorted ? 'flat' : 'outlined'" color="primary" size="small" class="rounded-pill d-print-none px-3 align-self-start ms-2 text-body-2 text-medium-emphasis">
+                Sort Decreasing
+            </v-btn>
             <v-card-text>        
                 <v-list>
                     <v-list-item border v-for="fv in dialogProperty.foodValues" :key="`${dialogProperty.id}_${fv.id}`">

--- a/vue3/src/components/display/PropertyView.vue
+++ b/vue3/src/components/display/PropertyView.vue
@@ -39,7 +39,8 @@
         <v-card v-if="dialogProperty" :loading="loading">
             <v-closable-card-title :title="`${dialogProperty.propertyAmountTotal} ${dialogProperty.unit} ${dialogProperty.name}`" :sub-title="$t('total')" icon="$properties"
                                    v-model="dialog"></v-closable-card-title>
-            <v-card-text>
+            <v-btn variant="outlined" size="small" class="rounded-pill d-print-none px-3 align-self-start ms-2 text-body-2 text-medium-emphasis">Sort Decreasing</v-btn>
+            <v-card-text>        
                 <v-list>
                     <v-list-item border v-for="fv in dialogProperty.foodValues" :key="`${dialogProperty.id}_${fv.id}`">
                         <template #prepend>

--- a/vue3/src/components/display/PropertyView.vue
+++ b/vue3/src/components/display/PropertyView.vue
@@ -39,7 +39,8 @@
         <v-card v-if="dialogProperty" :loading="loading">
             <v-closable-card-title :title="`${dialogProperty.propertyAmountTotal} ${dialogProperty.unit} ${dialogProperty.name}`" :sub-title="$t('total')" icon="$properties"
                                    v-model="dialog"></v-closable-card-title>
-            <v-btn @click="sortFoodValues" variant="outlined" size="small" class="rounded-pill d-print-none px-3 align-self-start ms-2 text-body-2 text-medium-emphasis">Sort Decreasing</v-btn>
+            <v-btn @click="sortFoodValues" :variant="isSorted ? 'flat' : 'outlined'" color="primary" size="small" class="rounded-pill d-print-none px-3 align-self-start ms-2 text-body-2 text-medium-emphasis">
+                Sort Decreasing</v-btn>
             <v-card-text>        
                 <v-list>
                     <v-list-item border v-for="fv in dialogProperty.foodValues" :key="`${dialogProperty.id}_${fv.id}`">

--- a/vue3/src/components/display/PropertyView.vue
+++ b/vue3/src/components/display/PropertyView.vue
@@ -27,7 +27,7 @@
                     <td v-if="sourceSelectedToShow == 'food'">
                         <v-btn @click="dialogProperty = p; dialog = true" variant="plain" color="warning" icon="fa-solid fa-triangle-exclamation" size="small" class="d-print-none"
                                v-if="p.missingValue"></v-btn>
-                        <v-btn @click="dialogProperty = p; dialog = true" variant="plain" icon="fa-solid fa-circle-info" size="small" v-if="!p.missingValue" class="d-print-none"></v-btn>
+                        <v-btn @click="dialogProperty = p; dialog = true; originalFoodValues = Object.values(toRaw(p.foodValues)); isSorted = false;" variant="plain" icon="fa-solid fa-circle-info" size="small" v-if="!p.missingValue" class="d-print-none"></v-btn>
                     </td>
                 </tr>
                 </tbody>
@@ -102,22 +102,29 @@ type PropertyWrapper = {
     type: PropertyType,
 }
 
+const originalFoodValues = ref<any[]>([]);
+const isSorted = ref(false);
 
 const sortFoodValues = () => {
-    const rawFoodValues = toRaw(dialogProperty.value?.foodValues);
-    if (rawFoodValues && typeof rawFoodValues === 'object') {
-        const foodValuesArray = Object.values(rawFoodValues);
-        const sorted = [...foodValuesArray].sort((a, b) => {
-            const percentageA = (a.value / dialogProperty.value.propertyAmountTotal) * 100;
-            const percentageB = (b.value / dialogProperty.value.propertyAmountTotal) * 100;
-            return percentageB - percentageA; // Sorting in decreasing order
-        });
-        dialogProperty.value.foodValues = sorted;
-        console.log('Sorted foodValues:', dialogProperty.value.foodValues);
-    } else {
-        console.error('foodValues is not an object or is undefined');
+    if (!dialogProperty.value) return;
+    if (isSorted.value) {
+        dialogProperty.value.foodValues = originalFoodValues.value.slice();
+        isSorted.value = false;
+        return;
     }
+    originalFoodValues.value = Object.values(toRaw(dialogProperty.value.foodValues));
+    const rawFoodValues = toRaw(dialogProperty.value.foodValues);
+    const foodValuesArray = Object.values(rawFoodValues);
+    const sorted = [...foodValuesArray].sort((a, b) => {
+        const percentageA = (a.value / dialogProperty.value.propertyAmountTotal) * 100;
+        const percentageB = (b.value / dialogProperty.value.propertyAmountTotal) * 100;
+        return percentageB - percentageA;
+    });
+
+    dialogProperty.value.foodValues = sorted;
+    isSorted.value = true;
 };
+
 
 
 


### PR DESCRIPTION
Issue Solved : #4186 
### New Feature
I implemented a 'Sort Decreasing' Button for the property ingredient window on a recipe so that users can sort and see which ingredients are contributing the most in a recipe. It doesn't showcase in property windows that have a warning in them, since not all values are there for sorting. Where the button is showcased, selecting it changes the color to signal that it is selected to the user, and the ingredients are sorted by decreasing percentage. Deselecting the button sets the ingredients back to the original order.

### Reasoning
Helps users identify primary contributors to a recipe. It can be helpful for figuring out which ingredients to substitute or take out to reach goals such as calorie goals.

### Implementation 
**Functions**

New constants 'originalFoodValues' and 'isSorted' are established. 'originalFoodValues' stores the original ingredient order so that it can be called when deselecting the sorting button. 'isSorted' is used for styling purposes. 

Function sortFoodValues creates a new list using the original food values and sorts it in decreasing order based on the percentage amount. It also updates 'isSorted' as needed.

**Styling**

A button is added to the property window card header with a thin outline and alignment with the text above it. Clicking the button styles it using the primary vue3 styling given. The button is not showcased when the property window has a warning.

### Testing
Manual Testing was done to ensure that the new functionality worked and was showcased only when appropriate. 

### Images 

Property Window open, showcasing an unselected button and ingredients that are not sorted. 
<img width="900" height="651" alt="Screenshot 2025-12-05 at 5 23 34 PM" src="https://github.com/user-attachments/assets/62fb36ff-3d7c-4335-929f-52d3ac1888b1" />

Property Window open, showcasing a selected button and ingredients sorted in decreasing order by percentage. 
<img width="900" height="651" alt="Screenshot 2025-12-05 at 5 23 41 PM" src="https://github.com/user-attachments/assets/dba89eb8-5e8e-40f4-8b9a-714ea03890fb" />

Button not shown in Property Windows where there are warnings
<img width="901" height="602" alt="Screenshot 2025-12-05 at 5 23 53 PM" src="https://github.com/user-attachments/assets/c9acb59f-c589-4052-a4f8-2655050c15dd" />



