### PR TITLE
fix: search by rating filter: <=

### DIFF
--- a/cookbook/helper/recipe_search.py
+++ b/cookbook/helper/recipe_search.py
@@ -430,7 +430,7 @@ class RecipeSearch():
         elif self._rating_gte:
             self._queryset = self._queryset.filter(rating__gte=int(self._rating_gte))
         elif self._rating_lte:
-            self._queryset = self._queryset.filter(rating__gte=int(self._rating_lte)).exclude(rating=0)
+            self._queryset = self._queryset.filter(rating__lte=int(self._rating_lte)).exclude(rating=0)
 
     def internal_filter(self, internal=None):
         if not internal:

--- a/cookbook/tests/other/test_recipe_full_text_search.py
+++ b/cookbook/tests/other/test_recipe_full_text_search.py
@@ -378,10 +378,12 @@ def test_search_count(found_recipe, recipes, param_type, u1_s1, u2_s1, space_1):
     assert r['count'] == 1
     assert found_recipe[0].id in [x['id'] for x in r['results']]
 
-    # this changed to fail after search api update but logic seems fine, disabling for now
-    # r = json.loads(u1_s1.get(reverse(LIST_URL) + param2).content)
-    # assert r['count'] == 1
-    # assert found_recipe[1].id in [x['id'] for x in r['results']]
+    # test lte filter (e.g. rating_lte=3).
+    # should match recipe with rating 1.0 (found_recipe[1])
+    # should not match recipe with rating 5.0 (found_recipe[0])
+    r = json.loads(u1_s1.get(reverse(LIST_URL) + param2).content)
+    assert r['count'] == 1
+    assert found_recipe[1].id in [x['id'] for x in r['results']]
 
     # test search for not rated/cooked
     r = json.loads(u1_s1.get(reverse(LIST_URL) + param3).content)


### PR DESCRIPTION
**Summary**
Fix the bug in the recipe search functionality where the <= "lte" rating filter was incorrectly applying >= "gte". 

**Detailed description**
As seen in https://github.com/TandoorRecipes/recipes/issues/4280, searching for recipes with a rating of 3 stars or less would return results for those of 3 stars or more instead. This is incorrect. 

The rating filter is defined in `cookbook/helper/recipe_search.py` and the query being run for the "lte" filter was actually the same as the "gte" filter. This fixes the issue. Also re-enable a commented test case that was failing but now passes with this fix, expanding the comment explaining how the test works. This test covers all of the rating filters.

**File changes:**
`cookbook/helper/recipe_search.py`
  - `rating_filter` method: correct `self._rating_lte` case
 
`cookbook/tests/other/test_recipe_full_text_search.py` 
  - `test_search_count`: uncomment the test case for the "lte=3" filter and explain why it works

Fixes https://github.com/TandoorRecipes/recipes/issues/4280