### PR TITLE
Add SOCIAL_DEFAULT_ACCESS support back in

### DIFF
--- a/cookbook/helper/permission_helper.py
+++ b/cookbook/helper/permission_helper.py
@@ -491,3 +491,15 @@ def create_space_for_user(user, name=None):
         user_space.groups.add(Group.objects.filter(name='admin').get())
 
         return user_space
+
+def add_social_user_default_space(user, active=True):
+    # If enabled, add a user that has logged in with a social account to the default group
+    # Group is defined by settings.SOCIAL_DEFAULT_ACCESS
+    # Access group to add the user to is defined by settings.SOCIAL_DEFAULT_GROUP
+    user_space = None
+
+    if settings.SOCIAL_DEFAULT_ACCESS:
+        user_space = UserSpace.objects.create(space=Space.objects.first(), user=user, active=active)
+        user_space.groups.add(Group.objects.filter(name=settings.SOCIAL_DEFAULT_GROUP).get())
+    
+    return user_space


### PR DESCRIPTION
Move code to handle SOCIAL_DEFAULT_ACCESS and SOCIAL_DEFAULT_GROUP settings into helper functions to restore functionality removed by commit 723b74509ff8d7253148f957e9965e515ba87d96 as identified by issue #4346

No change has been made to the logic of these settings - when SOCIAL_DEFAULT_ACCESS is enabled, users are added to the first space with the group specified by SOCIAL_DEFAULT_GROUP.

Further scope for enhancement would be to parse SOCIAL_DEFAULT_ACCESS as an integer (as indicated by the documentation) and use this as the space ID, rather than using Space.objects.first().

Another potential enhancement would be to check space membership on every login, and add the user to the configured space if they are not currently a member.