### PR TITLE
fix: Contradictory scheme headers with external reverse proxies

### DIFF
--- a/http.d/Recipes.conf.template
+++ b/http.d/Recipes.conf.template
@@ -19,6 +19,8 @@ server {
   # pass requests for dynamic content to gunicorn
   location / {
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Protocol "";
+
     proxy_pass http://unix:/run/tandoor.sock;
 
     # param needed by django allauth sessions to log IP


### PR DESCRIPTION
Fixes an issue if external reverse proxies send the `X-Forwarded-Protocol` and `X-Forwarded-Proto` headers at the same time.

Fixes #4187 