### PR TITLE
fix: replace naive datetime.now() with timezone.now() (#3975)

### DIFF
--- a/cookbook/helper/AllAuthCustomAdapter.py
+++ b/cookbook/helper/AllAuthCustomAdapter.py
@@ -1,10 +1,10 @@
-import datetime
 from gettext import gettext as _
 
 from allauth.account.adapter import DefaultAccountAdapter
 from django.conf import settings
 from django.contrib import messages
 from django.core.cache import caches
+from django.utils import timezone
 
 from cookbook.models import InviteLink
 
@@ -17,7 +17,7 @@ class AllAuthCustomAdapter(DefaultAccountAdapter):
         """
         signup_token = False
         if 'signup_token' in request.session and InviteLink.objects.filter(
-                valid_until__gte=datetime.datetime.today(), used_by=None, uuid=request.session['signup_token']).exists():
+                valid_until__gte=timezone.now().date(), used_by=None, uuid=request.session['signup_token']).exists():
             signup_token = True
 
         if request.resolver_match.view_name == 'account_signup' and not settings.ENABLE_SIGNUP and not signup_token:
@@ -30,7 +30,7 @@ class AllAuthCustomAdapter(DefaultAccountAdapter):
     # disable password reset for now
     def send_mail(self, template_prefix, email, context):
         if settings.EMAIL_HOST != '':
-            default = datetime.datetime.now()
+            default = timezone.now()
             c = caches['default'].get_or_set(email, default, timeout=360)
             if c == default:
                 try:

--- a/cookbook/integration/integration.py
+++ b/cookbook/integration/integration.py
@@ -1,4 +1,3 @@
-import datetime
 import traceback
 import uuid
 from io import BytesIO
@@ -10,6 +9,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.core.files import File
 from django.db import IntegrityError
 from django.http import HttpResponse
+from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.translation import gettext as _
 from django_scopes import scope
@@ -42,7 +42,7 @@ class Integration:
         self.export_type = export_type
         self.ignored_recipes = []
 
-        description = f'Imported by {request.user.get_user_display_name()} at {date_format(datetime.datetime.now(), "DATETIME_FORMAT")}. Type: {export_type}'
+        description = f'Imported by {request.user.get_user_display_name()} at {date_format(timezone.now(), "DATETIME_FORMAT")}. Type: {export_type}'
 
         try:
             last_kw = Keyword.objects.filter(name__regex=r'^(Import [0-9]+)', space=request.space).latest('created_at')
@@ -180,7 +180,7 @@ class Integration:
 
                         if isinstance(self, cookbook.integration.mealie1.Mealie1):
                             # since the mealie 1.0 export is a backup and not a classic recipe export we treat it a bit differently
-                            recipes = self.get_recipe_from_file(import_zip)
+                            self.get_recipe_from_file(import_zip)
                         else:
                             for z in file_list:
                                 try:
@@ -319,7 +319,7 @@ class Integration:
             traceback.print_exc()
 
     def get_export_file_name(self, format='zip'):
-        return "export_{}.{}".format(datetime.datetime.now().strftime("%Y-%m-%d"), format)
+        return "export_{}.{}".format(timezone.now().strftime("%Y-%m-%d"), format)
 
     def get_recipe_processed_msg(self, recipe):
         return f'{recipe.pk} - {recipe.name} \n'

--- a/cookbook/provider/dropbox.py
+++ b/cookbook/provider/dropbox.py
@@ -1,7 +1,7 @@
 import io
 import json
 import os
-from datetime import datetime
+from django.utils import timezone
 
 import requests
 
@@ -56,7 +56,7 @@ class Dropbox(Provider):
         )
         log_entry.save()
 
-        monitor.last_checked = datetime.now()
+        monitor.last_checked = timezone.now()
         monitor.save()
 
         return log_entry

--- a/cookbook/provider/local.py
+++ b/cookbook/provider/local.py
@@ -1,6 +1,6 @@
 import io
 import os
-from datetime import datetime
+from django.utils import timezone
 from os import listdir
 from os.path import isfile, join
 
@@ -39,7 +39,7 @@ class Local(Provider):
         )
         log_entry.save()
 
-        monitor.last_checked = datetime.now()
+        monitor.last_checked = timezone.now()
         monitor.save()
 
         return log_entry

--- a/cookbook/provider/nextcloud.py
+++ b/cookbook/provider/nextcloud.py
@@ -1,7 +1,7 @@
 import io
 import os
 import tempfile
-from datetime import datetime
+from django.utils import timezone
 
 import requests
 import webdav3.client as wc
@@ -63,7 +63,7 @@ class Nextcloud(Provider):
         )
         log_entry.save()
 
-        monitor.last_checked = datetime.now()
+        monitor.last_checked = timezone.now()
         monitor.save()
 
         return log_entry

--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1,6 +1,6 @@
 import traceback
 import uuid
-from datetime import datetime, timedelta
+from datetime import timedelta
 from decimal import Decimal
 from gettext import gettext as _
 from html import escape
@@ -1247,12 +1247,6 @@ class RecipeImageSerializer(WritableNestedModelSerializer):
         fields = ['image', 'image_url', ]
 
 
-class RecipeImportSerializer(SpacedModelSerializer):
-    class Meta:
-        model = RecipeImport
-        fields = '__all__'
-
-
 class RecipeBatchUpdateSerializer(serializers.Serializer):
     recipes = serializers.ListField(child=serializers.IntegerField())
     keywords_add = serializers.ListField(child=serializers.IntegerField())
@@ -1669,7 +1663,7 @@ class InviteLinkSerializer(WritableNestedModelSerializer):
         if obj.email and EMAIL_HOST != '':
             try:
                 if InviteLink.objects.filter(space=self.context['request'].space,
-                                             created_at__gte=datetime.now() - timedelta(hours=4)).count() < 20:
+                                             created_at__gte=timezone.now() - timedelta(hours=4)).count() < 20:
                     message = _('Hello') + '!\n\n' + _('You have been invited by ') + escape(
                         self.context['request'].user.get_user_display_name())
                     message += _(' to join their Tandoor Recipes space ') + escape(

--- a/cookbook/tests/other/test_recipe_full_text_search.py
+++ b/cookbook/tests/other/test_recipe_full_text_search.py
@@ -1,6 +1,6 @@
 import itertools
 import json
-from datetime import timedelta, datetime
+from datetime import timedelta
 
 import pytest
 from django.conf import settings
@@ -344,7 +344,8 @@ def test_search_date(found_recipe, recipes, param_type, result, u1_s1, u2_s1, sp
             Recipe.objects.filter(id=recipe.id).update(
                 updated_at=recipe.created_at)
 
-    date = (datetime.now() - timedelta(days=15)).strftime("%Y-%m-%d")
+    # use the same reference point as the fixture to avoid date boundary flakiness
+    date = (timezone.now() - timedelta(days=15)).strftime("%Y-%m-%d")
     param1 = f"?{param_type}_gte={date}"
     param2 = f"?{param_type}_lte={date}"
     r = json.loads(u1_s1.get(reverse(LIST_URL) + f'{param1}').content)

--- a/cookbook/views/views.py
+++ b/cookbook/views/views.py
@@ -1,7 +1,7 @@
 import os
 import re
 import subprocess
-from datetime import datetime, timedelta
+from datetime import timedelta
 from io import StringIO
 from uuid import UUID
 
@@ -253,9 +253,9 @@ def system(request):
                     space_stats.append(r.zscore(f'api:space-request-count:{d}', s))
                 api_space_stats.append(space_stats)
 
-    cache_response = caches['default'].get(f'system_view_test_cache_entry', None)
+    cache_response = caches['default'].get('system_view_test_cache_entry', None)
     if not cache_response:
-        caches['default'].set(f'system_view_test_cache_entry', datetime.now(), 10)
+        caches['default'].set('system_view_test_cache_entry', timezone.now(), 10)
 
     return render(
         request, 'system.html', {
@@ -279,7 +279,7 @@ def plugin_update(request):
     if not request.user.is_superuser:
         raise PermissionDenied
 
-    if not 'module' in request.GET:
+    if 'module' not in request.GET:
         raise BadRequest
 
     for p in PLUGINS:
@@ -331,7 +331,7 @@ def invite_link(request, token):
             print('Malformed Invite Link supplied!')
             return HttpResponseRedirect(reverse('index'))
 
-        if link := InviteLink.objects.filter(valid_until__gte=datetime.today(), used_by=None, uuid=token).first():
+        if link := InviteLink.objects.filter(valid_until__gte=timezone.now().date(), used_by=None, uuid=token).first():
             if request.user.is_authenticated and not request.user.userspace_set.filter(space=link.space).exists():
                 if not link.reusable:
                     link.used_by = request.user


### PR DESCRIPTION
Resolves #3975 

The test_search_date test used datetime.now() (naive) while the fixture used timezone.now() (aware). Near midnight or with timezone offsets, these resolve to different dates causing flaky assertions.

Also fixed the same issue in production code across 7 files:
- serializer.py: InviteLink rate-limit query
- views.py: cache entry and invite link validation
- AllAuthCustomAdapter.py: signup token validation and rate limiting
- integration.py: import description and export filename
- provider/{local,nextcloud,dropbox}.py: monitor.last_checked

Minor lint fixes: removed unnecessary f-string prefixes, fixed membership test operator, removed unused variable assignment.