### PR TITLE
fix: mark field as nullable in Keyword and Food serializers

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -872,7 +872,7 @@ class FoodSimpleSerializer(serializers.ModelSerializer):
 class FoodSerializer(UniqueFieldsMixin, WritableNestedModelSerializer, ExtendedRecipeMixin, OpenDataModelMixin):
     supermarket_category = SupermarketCategorySerializer(allow_null=True, required=False)
     recipe = RecipeSimpleSerializer(allow_null=True, required=False)
-    shopping = serializers.CharField(source='shopping_status', read_only=True)
+    shopping = serializers.CharField(source='shopping_status', read_only=True, required=False)
     inherit_fields = FoodInheritFieldSerializer(many=True, allow_null=True, required=False)
     child_inherit_fields = FoodInheritFieldSerializer(many=True, allow_null=True, required=False)
     food_onhand = CustomOnHandField(required=False, allow_null=True)


### PR DESCRIPTION
I am building a client for the Tandoor API, auto-generated from the OpenAPI spec. While working on this, I encountered mismatches between the spec and the actual data returned by the API — specifically around nullable fields that weren't marked as such in the schema. This PR fixes the cases I found.