### PR TITLE
fix: add missing JSON keyword to AI properties prompts and improve error handling

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1203,7 +1203,7 @@ class FoodViewSet(LoggingMixin, TreeMixin, DeleteRelationMixing):
                     "content": [
                         {
                             "type": "text",
-                            "text": "Given the following food and the following different types of properties please update the food so that the properties attribute contains a list with all property types in the following format [{property_amount: <the property value>, property_type: {id: <the ID of the property type>, name: <the name of the property type>}}]."
+                            "text": "Given the following food and the following different types of properties please update the food so that the properties attribute contains a list with all property types in the following JSON format [{property_amount: <the property value>, property_type: {id: <the ID of the property type>, name: <the name of the property type>}}]. Return only valid JSON."
                                     "The property values should be in the unit given in the property type and for the amount specified in the properties_food_amount attribute of the food, which is given in the properties_food_unit."
                                     "property_amount is a decimal number. Please try to keep a precision of two decimal places if given in your source data."
                                     "Do not make up any data. If there is no data available for the given property type that is ok, just return null as a property_amount for that property type. Do not change anything else!"
@@ -1248,6 +1248,13 @@ class FoodViewSet(LoggingMixin, TreeMixin, DeleteRelationMixing):
                     'msg': 'The AI could not process your request. \n\n' + err.message,
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
+            except Exception as err:
+                traceback.print_exc()
+                response = {
+                    'error': True,
+                    'msg': 'An unexpected error occurred while processing your AI request. \n\n' + str(err),
+                }
+                return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     def destroy(self, *args, **kwargs):
@@ -1977,7 +1984,7 @@ class RecipeViewSet(LoggingMixin, viewsets.ModelViewSet, DeleteRelationMixing):
                     "content": [
                         {
                             "type": "text",
-                            "text": "Given the following recipe and the following different types of properties please update the recipe so that the properties attribute contains a list with all property types in the following format [{property_amount: <the property value>, property_type: {id: <the ID of the property type>, name: <the name of the property type>}}]."
+                            "text": "Given the following recipe and the following different types of properties please update the recipe so that the properties attribute contains a list with all property types in the following JSON format [{property_amount: <the property value>, property_type: {id: <the ID of the property type>, name: <the name of the property type>}}]. Return only valid JSON."
                                     "The property values should be in the unit given in the property type and calculated based on the total quantity of the foods used for the recipe."
                                     "property_amount is a decimal number. Please try to keep a precision of two decimal places if given in your source data."
                                     "Do not make up any data. If there is no data available for the given property type that is ok, just return null as a property_amount for that property type. Do not change anything else!"
@@ -2022,6 +2029,13 @@ class RecipeViewSet(LoggingMixin, viewsets.ModelViewSet, DeleteRelationMixing):
                     'msg': 'The AI could not process your request. \n\n' + err.message,
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
+            except Exception as err:
+                traceback.print_exc()
+                response = {
+                    'error': True,
+                    'msg': 'An unexpected error occurred while processing your AI request. \n\n' + str(err),
+                }
+                return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     @extend_schema(responses=RecipeSerializer(many=False))
@@ -2841,6 +2855,13 @@ class AiStepSortView(APIView):
                     'msg': 'The AI could not process your request. \n\n' + err.message,
                 }
                 return Response(response, status=status.HTTP_400_BAD_REQUEST)
+            except Exception as err:
+                traceback.print_exc()
+                response = {
+                    'error': True,
+                    'msg': 'An unexpected error occurred while processing your AI request. \n\n' + str(err),
+                }
+                return Response(response, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
 


### PR DESCRIPTION
## Summary

Fixes #4384

The `aiproperties` action on both `FoodViewSet` and `RecipeViewSet` uses `response_format: {"type": "json_object"}` with litellm, but the prompt text never contains the word **JSON**. Many LLM providers (OpenAI, Azure, etc.) require the word "JSON" to appear somewhere in the messages when using structured JSON output mode -- without it, the API returns a `BadRequestError`.

### Changes

1. **Added "JSON" to prompt text** in both `FoodViewSet.aiproperties` and `RecipeViewSet.aiproperties` -- changed "in the following format" to "in the following JSON format" and appended "Return only valid JSON." This matches the pattern already used by the file/text import prompts elsewhere in the same file.

2. **Added generic `Exception` handler** to the `try/except` blocks in all three AI action methods (`FoodViewSet.aiproperties`, `RecipeViewSet.aiproperties`, and `AiStepSortView`). Previously, only `LitellmTimeout` and `BadRequestError` were caught -- any other exception (e.g., `JSONDecodeError` from malformed AI response, unexpected litellm errors) would propagate as an unhandled 500 with no useful information returned to the user. The new handler logs the full traceback server-side and returns a descriptive error message to the client.

### Testing

- Verified the prompt text change is consistent with the existing AI import prompts in the same file (lines 2668 and 2686) which already include "JSON"
- The generic exception handler follows the same pattern as the existing `BadRequestError` handler but with `HTTP_500_INTERNAL_SERVER_ERROR` status
- No new dependencies or migrations required