### PR TITLE
fix: preserve Unicode characters in AI prompts by using ensure_ascii=False

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1220,11 +1220,11 @@ class FoodViewSet(LoggingMixin, TreeMixin, DeleteRelationMixing):
                         },
                         {
                             "type": "text",
-                            "text": json.dumps(request.data)
+                            "text": json.dumps(request.data, ensure_ascii=False)
                         },
                         {
                             "type": "text",
-                            "text": json.dumps(property_type_list)
+                            "text": json.dumps(property_type_list, ensure_ascii=False)
                         },
                     ]
                 },
@@ -2005,11 +2005,11 @@ class RecipeViewSet(LoggingMixin, viewsets.ModelViewSet, DeleteRelationMixing):
                         },
                         {
                             "type": "text",
-                            "text": json.dumps(request.data)
+                            "text": json.dumps(request.data, ensure_ascii=False)
                         },
                         {
                             "type": "text",
-                            "text": json.dumps(property_type_list)
+                            "text": json.dumps(property_type_list, ensure_ascii=False)
                         },
                     ]
                 },
@@ -2834,7 +2834,7 @@ class AiStepSortView(APIView):
                         },
                         {
                             "type": "text",
-                            "text": json.dumps(request.data)
+                            "text": json.dumps(request.data, ensure_ascii=False)
                         },
 
                     ]


### PR DESCRIPTION
## Problem

When using AI features (step sorting, food/recipe AI properties), non-ASCII characters such as German umlauts (ä, ö, ü, ß) are not preserved correctly. The AI returns garbled output like:

- `kräftig` → `kre4ftig`
- `andünsten` → `andfcnsten`
- `mitrösten` → `mitrf6sten`
- `Brühe` → `Brfche`
- `ablöschen` → `ablf6schen`

## Root Cause

`json.dumps()` is called without `ensure_ascii=False` when constructing the AI prompt. By default, `json.dumps` escapes all non-ASCII characters as `\uXXXX` sequences (e.g. `ä` becomes `\u00e4`). When the AI model is instructed to return the data "unchanged", some models mishandle these escape sequences and strip the `\u00` prefix, leaving only the hex digits (e.g. `e4` instead of `ä`).

## Fix

Add `ensure_ascii=False` to all `json.dumps()` calls used in AI prompts. This sends the actual Unicode characters to the AI (e.g. `ä` instead of `\u00e4`), so the model receives and returns human-readable text without any escape sequences to mishandle.

## Affected endpoints

- `FoodViewSet.aiproperties` – food-level AI property generation
- `RecipeViewSet.aiproperties` – recipe-level AI property generation  
- `AiStepSortView` – AI-powered step sorting

## Changes

```diff
-  "text": json.dumps(request.data)
+  "text": json.dumps(request.data, ensure_ascii=False)

-  "text": json.dumps(property_type_list)
+  "text": json.dumps(property_type_list, ensure_ascii=False)
```

5 lines changed in `cookbook/views/api.py`.

## Test plan

- [ ] Open a recipe with German (or other non-ASCII) text in the ingredients/steps
- [ ] Use "Edit → Steps → Auto-sort" with an AI provider configured
- [ ] Verify that umlauts (ä, ö, ü) are preserved correctly in the returned steps
- [ ] Repeat for Food AI properties feature