### PR TITLE
fix: propagate user language to Luxon, Vuetify, and vue-simple-calendar

### DIFF
--- a/vue3/src/components/display/MealPlanView.vue
+++ b/vue3/src/components/display/MealPlanView.vue
@@ -5,6 +5,7 @@
                 <!-- TODO add hint about CTRL key while drag/drop -->
                 <!-- TODO multi selection? date range selection ? -->
                 <calendar-view
+                    :locale="locale"
                     :show-date="calendarDate"
                     :items="planItems"
                     class="theme-default"
@@ -50,6 +51,7 @@ import "vue-simple-calendar/dist/css/default.css"
 import MealPlanCalendarItem from "@/components/display/MealPlanCalendarItem.vue";
 import {IMealPlanCalendarItem, IMealPlanNormalizedCalendarItem} from "@/types/MealPlan";
 import {computed, onMounted, ref, watch} from "vue";
+import {useI18n} from "vue-i18n";
 import {DateTime, Duration} from "luxon";
 import {useDisplay} from "vuetify";
 import {useMealPlanStore} from "@/stores/MealPlanStore";
@@ -59,6 +61,7 @@ import {useUserPreferenceStore} from "@/stores/UserPreferenceStore";
 import MealPlanCalendarHeader from "@/components/display/MealPlanCalendarHeader.vue";
 
 const {lgAndUp} = useDisplay()
+const {locale} = useI18n()
 
 const calendarDate = ref(new Date())
 

--- a/vue3/src/i18n.ts
+++ b/vue3/src/i18n.ts
@@ -5,6 +5,8 @@ import type {
     Locale,
 } from 'vue-i18n'
 
+import {Settings} from 'luxon'
+
 import {createI18n} from "vue-i18n";
 import en from "../../vue3/src/locales/en.json";
 import {TANDOOR_PLUGINS} from "@/types/Plugins.ts";
@@ -110,10 +112,11 @@ function getSupportedLocales(localeFiles = import.meta.glob('@/locales/*.json'))
 }
 
 /**
- * set the active locale (determining which messages to show) for Vue i18n
+ * set the active locale (determining which messages to show) for Vue i18n and Luxon date formatting
  * @param i18n instance of Vue i18n
  * @param locale string locale code to set (should be in SUPPORT_LOCALES)
  */
 export function setLocale(i18n: I18n, locale: Locale): void {
     i18n.global.locale = locale
+    Settings.defaultLocale = locale
 }

--- a/vue3/src/vuetify.ts
+++ b/vue3/src/vuetify.ts
@@ -7,6 +7,12 @@ import {createVuetify} from 'vuetify'
 import {DateTime} from "luxon";
 import {af, ar, az, bg, ca, ckb, cs, da, de, el, en, es, et, fi, fr, he, hr, hu, id, it, ja, km, ko, lt, lv, nl, no, pl, pt, ro, ru, sk, sl, srCyrl, srLatn, sv, th, tr, uk, vi, zhHans, zhHant} from "vuetify/locale";
 
+function getVuetifyLocale(): string {
+    const lang = document.querySelector('html')?.getAttribute('lang') ?? 'en'
+    // Vuetify uses camelCase for compound locales (zh-Hans → zhHans, sr-Cyrl → srCyrl)
+    return lang.replace(/-([A-Z])/g, (_, c: string) => c.toLowerCase()).replace(/-([a-z])/g, (_, c: string) => c.toUpperCase())
+}
+
 // https://vuetifyjs.com/en/introduction/why-vuetify/#feature-guides
 export default createVuetify({
     defaults: {
@@ -36,7 +42,7 @@ export default createVuetify({
         // }
     },
     locale: {
-        locale: 'en',
+        locale: getVuetifyLocale(),
         fallback: 'en',
         messages: {af, ar, az, bg, ca, ckb, cs, da, de, el, en, es, et, fi, fr, he, hr, hu, id, it, ja, km, ko, lt, lv, nl, no, pl, pt, ro, ru, sk, sl, srCyrl, srLatn, sv, th, tr, uk, vi, zhHans, zhHant},
         decimalSeparator: 0.1.toLocaleString().replace(/\d/g, '')


### PR DESCRIPTION
Dates across the app were formatted using the browser/OS locale instead of the user's selected language in Tandoor.

## Changes
- Set `Settings.defaultLocale` in `setLocale()` so all `DateTime.toLocaleString()` calls use the correct locale
- Derive Vuetify's initial locale from the HTML `lang` attribute at startup so date pickers render correctly
- Pass the vue-i18n locale to `vue-simple-calendar` so meal plan calendar day headers follow the user's language

## Future improvement
Vuetify provides a `createVueI18nAdapter` that would keep Vuetify's locale automatically in sync with vue-i18n, removing the need for the HTML `lang` workaround. This requires migrating to vue-i18n's composition mode (`legacy: false`), which is a larger refactor.