### PR TITLE
fix: deduplicate recipes in recipe books

### DIFF
--- a/vue3/src/pages/BookViewPage.vue
+++ b/vue3/src/pages/BookViewPage.vue
@@ -167,8 +167,10 @@ function recLoadFilter(filterId: number, page: number) {
     let api = new ApiApi()
 
     api.apiRecipeList({filter: filterId, page: page, pageSize: 50}).then(r => {
-        recipes.value = recipes.value.concat(r.results)
-        filterItems.value = r.count
+        const existingIds = new Set(recipes.value.map(rec => rec.id))
+        const newRecipes = r.results.filter(rec => !existingIds.has(rec.id))
+        recipes.value = recipes.value.concat(newRecipes)
+        filterItems.value = recipes.value.length - manualItems.value
         if (r.next) {
             recLoadFilter(filterId, page + 1)
         } else {


### PR DESCRIPTION
fixes #3584

Books with both manual entries and a saved search filter showed duplicate recipes when a manually-added recipe also matched the filter.

- Filter out already-loaded recipe IDs before concatenating filter results in `recLoadFilter()`
- Derive `filterItems` count from actual unique recipes instead of raw API count