### PR TITLE
Add daily nutrition totals to meal plan views

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1389,6 +1389,32 @@ class MealPlanSerializer(SpacedModelSerializer, WritableNestedModelSerializer):
     shared = UserSerializer(many=True, required=False, allow_null=True)
     shopping = serializers.SerializerMethodField('in_shopping')
     addshopping = serializers.BooleanField(write_only=True, required=False)
+    nutrition = serializers.SerializerMethodField("get_nutrition", read_only=True)
+
+    def get_nutrition(self, obj):
+        if not obj.recipe:
+            return None
+        result = {}
+        try:
+            from cookbook.helper.property_helper import FoodPropertyHelper
+            food_props = FoodPropertyHelper(self.context["request"].space).calculate_recipe_properties(obj.recipe)
+            if food_props:
+                for prop_id, prop_data in food_props.items():
+                    name = prop_data.get("name", "")
+                    total = prop_data.get("total_value", 0)
+                    if name == "Calories": result["calories"] = total
+                    elif name == "Proteins": result["proteins"] = total
+                    elif name == "Fats": result["fats"] = total
+                    elif name == "Carbohydrates": result["carbohydrates"] = total
+                    elif name == "Saturated fats": result["saturated_fat"] = total
+                    elif name == "Sugars": result["sugars"] = total
+        except Exception:
+            pass
+        has_meaningful = result and any(v > 0 for v in result.values() if isinstance(v, (int, float)))
+        if not has_meaningful and obj.recipe.nutrition:
+            n = obj.recipe.nutrition
+            result = {"calories": float(n.calories), "proteins": float(n.proteins), "fats": float(n.fats), "carbohydrates": float(n.carbohydrates)}
+        return result if result else None
 
     to_date = serializers.DateTimeField(required=False)
 
@@ -1458,9 +1484,9 @@ class MealPlanSerializer(SpacedModelSerializer, WritableNestedModelSerializer):
         fields = (
             'id', 'title', 'recipe', 'servings', 'note', 'note_markdown',
             'from_date', 'to_date', 'meal_type', 'created_by', 'shared', 'recipe_name',
-            'meal_type_name', 'shopping', 'addshopping'
+            'meal_type_name', 'shopping', 'addshopping', 'nutrition'
         )
-        read_only_fields = ('created_by',)
+        read_only_fields = ('created_by', 'nutrition')
 
 
 class AutoMealPlanSerializer(serializers.Serializer):

--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1454,7 +1454,7 @@ class MealPlanViewSet(LoggingMixin, viewsets.ModelViewSet):
     required_scopes = ['mealplan']
 
     def get_queryset(self):
-        queryset = self.queryset.filter(Q(created_by=self.request.user) |
+        queryset = self.queryset.select_related("recipe__nutrition").filter(Q(created_by=self.request.user) |
                                         Q(created_by_id__in=UserSpace.objects.filter(household=self.request.user_space.household, household__isnull=False).values_list('user_id', flat=True))).filter(
             space=self.request.space).distinct().all()
 

--- a/vue3/src/components/display/HorizontalMealPlanWindow.vue
+++ b/vue3/src/components/display/HorizontalMealPlanWindow.vue
@@ -56,6 +56,21 @@
                                         </v-btn>
                                     </template>
                                 </v-list-item>
+                                <!-- Daily Nutrition Totals -->
+                                <template v-if="getDayNutrition(mealPlanGridItem.date)">
+                                    <v-divider></v-divider>
+                                    <v-list-item density="compact" class="text-caption pa-2">
+                                        <div class="d-flex flex-column" style="gap: 3px; font-size: 0.75rem">
+                                            <div><strong style="color: #e65100">{{ Math.round(getDayNutrition(mealPlanGridItem.date).calories) }} kcal</strong></div>
+                                            <div style="color: #c62828">Protein: {{ Math.round(getDayNutrition(mealPlanGridItem.date).proteins) }}g</div>
+                                            <div style="color: #1565c0">Carbs: {{ Math.round(getDayNutrition(mealPlanGridItem.date).carbohydrates) }}g</div>
+                                            <div style="color: #2e7d32">Fat: {{ Math.round(getDayNutrition(mealPlanGridItem.date).fats) }}g</div>
+                                            <div style="color: #6a1b9a">Sat. fat: {{ Math.round(getDayNutrition(mealPlanGridItem.date).saturatedFats) }}g</div>
+                                            <div style="color: #00838f">Sugar: {{ Math.round(getDayNutrition(mealPlanGridItem.date).sugars) }}g</div>
+                                        </div>
+                                    </v-list-item>
+                                </template>
+
                                 <v-list-item class="text-center cursor-pointer" variant="tonal">
                                     <model-edit-dialog model="MealPlan" :item-defaults="{fromDate: mealPlanGridItem.date.toJSDate()}" :close-after-create="false"
                                                        :close-after-save="false"></model-edit-dialog>
@@ -145,6 +160,11 @@ onMounted(() => {
         loading.value = false
     })
 })
+
+function getDayNutrition(date: DateTime): { calories: number; proteins: number; fats: number; carbohydrates: number; saturatedFats: number; sugars: number; mealCount: number } | null {
+    const dateKey = date.toISODate() as string
+    return useMealPlanStore().dailyNutritionTotals.get(dateKey) ?? null
+}
 
 function clickMealPlan(plan: MealPlan) {
     if (plan.recipe) {

--- a/vue3/src/components/display/MealPlanCalendarItem.vue
+++ b/vue3/src/components/display/MealPlanCalendarItem.vue
@@ -1,5 +1,21 @@
 <template>
-    <v-card class="card cv-item pa-0" hover
+    <!-- Daily nutrition summary card -->
+    <v-card v-if="mealPlan.id === -999" class="card cv-item pa-0"
+            :style="{'top': itemTop, 'height': 'auto', 'background-color': '#f5f5f5', 'border-color': '#ccc'}"
+            :key="value.id"
+            :class="value.classes"
+            flat>
+        <v-card-text class="pa-1" style="font-size: 0.7rem; line-height: 1.3">
+            <div><strong style="color: #e65100">{{ Math.round(mealPlan.nutrition?.calories ?? 0) }} kcal</strong></div>
+            <div style="color: #c62828">Protein: {{ Math.round(mealPlan.nutrition?.proteins ?? 0) }}g</div>
+            <div style="color: #1565c0">Carbs: {{ Math.round(mealPlan.nutrition?.carbohydrates ?? 0) }}g</div>
+            <div style="color: #2e7d32">Fat: {{ Math.round(mealPlan.nutrition?.fats ?? 0) }}g</div>
+            <div style="color: #6a1b9a">Sat. fat: {{ Math.round(mealPlan.nutrition?.saturatedFats ?? 0) }}g</div>
+            <div style="color: #00838f">Sugar: {{ Math.round(mealPlan.nutrition?.sugars ?? 0) }}g</div>
+        </v-card-text>
+    </v-card>
+    <!-- Regular meal plan card -->
+    <v-card v-else class="card cv-item pa-0" hover
             :style="{'top': itemTop, 'height': itemHeight, 'border-color': mealPlan.mealType.color}"
             :draggable="true"
             :key="value.id"

--- a/vue3/src/components/display/MealPlanView.vue
+++ b/vue3/src/components/display/MealPlanView.vue
@@ -81,6 +81,38 @@ const planItems = computed(() => {
             mealPlan: mp,
         } as IMealPlanCalendarItem)
     })
+    // Add daily nutrition summary after the last meal plan item for each day
+    const lastItemPerDay = new Map()
+    useMealPlanStore().planList.forEach(mp => {
+        if (!mp.fromDate) return
+        const dk = DateTime.fromJSDate(mp.fromDate).toISODate()
+        const existing = lastItemPerDay.get(dk)
+        if (!existing || mp.fromDate.getTime() > existing.date.getTime()) {
+            lastItemPerDay.set(dk, { date: mp.fromDate, mp })
+        }
+    })
+
+    useMealPlanStore().dailyNutritionTotals.forEach((totals, dateKey) => {
+        const last = lastItemPerDay.get(dateKey)
+        if (!last) return
+        const summaryDate = new Date(last.date.getTime() + 60000)
+        items.push({
+            startDate: summaryDate,
+            endDate: summaryDate,
+            id: last.mp.id + 900000,
+            title: Math.round(totals.calories) + ' kcal',
+            mealPlan: {
+                id: -999,
+                fromDate: summaryDate,
+                toDate: summaryDate,
+                servings: 1,
+                title: Math.round(totals.calories) + ' kcal',
+                mealType: last.mp.mealType,
+                nutrition: totals,
+            },
+        })
+    })
+
     return items
 })
 

--- a/vue3/src/openapi/models/MealPlan.ts
+++ b/vue3/src/openapi/models/MealPlan.ts
@@ -128,6 +128,7 @@ export interface MealPlan {
      * @memberof MealPlan
      */
     addshopping?: boolean;
+    readonly nutrition?: any;
 }
 
 /**
@@ -170,6 +171,7 @@ export function MealPlanFromJSONTyped(json: any, ignoreDiscriminator: boolean): 
         'mealTypeName': json['meal_type_name'],
         'shopping': json['shopping'],
         'addshopping': json['addshopping'] == null ? undefined : json['addshopping'],
+        'nutrition': json['nutrition'] == null ? undefined : json['nutrition'],
     };
 }
 

--- a/vue3/src/stores/MealPlanStore.ts
+++ b/vue3/src/stores/MealPlanStore.ts
@@ -160,7 +160,27 @@ export const useMealPlanStore = defineStore(_STORE_ID, () => {
     //         return JSON.parse(s)
     //     }
     // }
-    return {plans, currently_updating, planList, loading, refreshFromAPI, createObject, updateObject, deleteObject, refreshLastUpdatedPeriod, createOrUpdate}
+    const dailyNutritionTotals = computed(() => {
+        const totals = new Map<string, { calories: number; proteins: number; fats: number; carbohydrates: number; saturatedFats: number; sugars: number; mealCount: number }>()
+        planList.value.forEach((mp: MealPlan) => {
+            if (!mp.nutrition || !mp.fromDate) return
+            const dateKey = DateTime.fromJSDate(new Date(mp.fromDate as unknown as string)).toISODate() as string
+            if (!dateKey) return
+            const servingScale = (mp.servings ?? 1) / (mp.recipe?.servings ?? 1)
+            const existing = totals.get(dateKey) ?? { calories: 0, proteins: 0, fats: 0, carbohydrates: 0, saturatedFats: 0, sugars: 0, mealCount: 0 }
+            existing.calories += (mp.nutrition.calories ?? 0) * servingScale
+            existing.proteins += (mp.nutrition.proteins ?? 0) * servingScale
+            existing.fats += (mp.nutrition.fats ?? 0) * servingScale
+            existing.carbohydrates += (mp.nutrition.carbohydrates ?? 0) * servingScale
+            existing.saturatedFats += (mp.nutrition.saturated_fat ?? 0) * servingScale
+            existing.sugars += (mp.nutrition.sugars ?? 0) * servingScale
+            existing.mealCount += 1
+            totals.set(dateKey, existing)
+        })
+        return totals
+    })
+
+    return {plans, currently_updating, planList, loading, refreshFromAPI, createObject, updateObject, deleteObject, refreshLastUpdatedPeriod, createOrUpdate, dailyNutritionTotals}
 })
 
 // enable hot reload for store


### PR DESCRIPTION
Display per-day macro summaries (calories, protein, carbs, fat, saturated fat, sugar) on both the homepage horizontal meal plan and the calendar view.

Backend:
- MealPlanSerializer: add computed `nutrition` field that resolves per-recipe macros via FoodPropertyHelper, with fallback to recipe.nutrition
- MealPlanViewSet: add select_related("recipe__nutrition") to avoid N+1 queries

Frontend:
- MealPlanStore: add dailyNutritionTotals computed map (date -> totals), scaling by servings
- HorizontalMealPlanWindow: render daily totals below each day's meals
- MealPlanCalendarItem: render nutrition summary card (id=-999 sentinel)
- MealPlanView: inject summary items into calendar after last meal per day
- MealPlan.ts: add nutrition field to model and JSON parser

This is 100% vibe coded with Claude. Maybe it helps you guys to implement the feature fully or someone else to clone this and use it locally.