### PR TITLE
add bulk delete option for meal plan entries (#4492)

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1473,6 +1473,41 @@ class AutoMealPlanSerializer(serializers.Serializer):
     addshopping = serializers.BooleanField()
 
 
+class MealPlanBulkDeleteSerializer(serializers.Serializer):
+    ids = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False,
+        help_text=_('IDs of specific meal plans to delete.')
+    )
+    from_date = serializers.DateTimeField(
+        required=False,
+        help_text=_('Start of date range (inclusive) to delete meal plans for.')
+    )
+    to_date = serializers.DateTimeField(
+        required=False,
+        help_text=_('End of date range (inclusive) to delete meal plans for.')
+    )
+
+    def validate(self, attrs):
+        ids = attrs.get('ids') or []
+        from_date = attrs.get('from_date')
+        to_date = attrs.get('to_date')
+
+        if not ids and not (from_date and to_date):
+            raise serializers.ValidationError(
+                _('You must provide either ids or both from_date and to_date.'))
+
+        if (from_date and not to_date) or (to_date and not from_date):
+            raise serializers.ValidationError(
+                _('Both from_date and to_date are required when using a date range.'))
+
+        if from_date and to_date and from_date > to_date:
+            raise serializers.ValidationError(
+                _('from_date must be before or equal to to_date.'))
+
+        return attrs
+
+
 class ShoppingListRecipeSerializer(serializers.ModelSerializer):
     recipe_data = RecipeOverviewSerializer(source='recipe', read_only=True, required=False)
     meal_plan_data = MealPlanSerializer(source='mealplan', read_only=True, required=False)

--- a/cookbook/tests/api/test_api_meal_plan.py
+++ b/cookbook/tests/api/test_api_meal_plan.py
@@ -10,12 +10,13 @@ from icalendar import Calendar
 from oauth2_provider.models import AccessToken
 from rest_framework.test import APIClient
 
-from cookbook.models import MealPlan, MealType
-from cookbook.tests.factories import RecipeFactory
+from cookbook.models import MealPlan, MealType, ShoppingListEntry
+from cookbook.tests.factories import RecipeFactory, ShoppingListEntryFactory, ShoppingListRecipeFactory
 
 LIST_URL = 'api:mealplan-list'
 DETAIL_URL = 'api:mealplan-detail'
 ICAL_URL = 'api:mealplan-ical'
+BULK_DELETE_URL = 'api:mealplan-bulk-delete'
 
 # NOTE: auto adding shopping list from meal plan is tested in test_shopping_recipe as tests are identical
 
@@ -402,3 +403,108 @@ def test_create_explicit_time_preserved(u1_s1, recipe_1_s1, space_1):
         mp = MealPlan.objects.get(pk=response['id'])
     assert mp.from_date.hour == 19
     assert mp.from_date.minute == 30
+
+
+def test_bulk_delete_by_ids_deletes_meal_plans_and_shopping(u1_s1, u2_s1, obj_1, obj_2, obj_3, recipe_1_s1, meal_type, space_1):
+    other_mealplan = MealPlan.objects.create(
+        recipe=recipe_1_s1,
+        space=space_1,
+        meal_type=meal_type,
+        from_date=timezone.now(),
+        to_date=timezone.now(),
+        created_by=auth.get_user(u2_s1),
+    )
+
+    # Shopping data tied to each meal plan
+    with scopes_disabled():
+        slr_1 = ShoppingListRecipeFactory(mealplan=obj_1, space=space_1, created_by=auth.get_user(u1_s1))
+        slr_2 = ShoppingListRecipeFactory(mealplan=obj_2, space=space_1, created_by=auth.get_user(u1_s1))
+        slr_other = ShoppingListRecipeFactory(mealplan=other_mealplan, space=space_1, created_by=auth.get_user(u2_s1))
+
+        ShoppingListEntryFactory(list_recipe=slr_1, space=space_1)
+        ShoppingListEntryFactory(list_recipe=slr_2, space=space_1)
+        ShoppingListEntryFactory(list_recipe=slr_other, space=space_1)
+
+    r = u1_s1.post(
+        reverse(BULK_DELETE_URL),
+        {'ids': [obj_1.id, obj_2.id]},
+        content_type='application/json',
+    )
+
+    assert r.status_code == 200
+
+    with scopes_disabled():
+        assert not MealPlan.objects.filter(id__in=[obj_1.id, obj_2.id]).exists()
+        assert MealPlan.objects.filter(id=obj_3.id).exists()
+        assert MealPlan.objects.filter(id=other_mealplan.id).exists()
+
+        assert not ShoppingListEntry.objects.filter(list_recipe__mealplan_id__in=[obj_1.id, obj_2.id]).exists()
+        assert ShoppingListEntry.objects.filter(list_recipe__mealplan_id=other_mealplan.id).exists()
+
+
+def test_bulk_delete_by_date_range_deletes_overlapping_meal_plans(u1_s1, recipe_1_s1, meal_type, space_1):
+    now = timezone.localtime(timezone.now()).replace(second=0, microsecond=0, hour=12, minute=0)
+    from_dt = now
+    to_dt = now + timedelta(days=3)
+
+    in_range_1 = MealPlan.objects.create(
+        recipe=recipe_1_s1,
+        space=space_1,
+        meal_type=meal_type,
+        from_date=now - timedelta(days=1),
+        to_date=now + timedelta(days=1),
+        created_by=auth.get_user(u1_s1),
+    )
+    in_range_2 = MealPlan.objects.create(
+        recipe=recipe_1_s1,
+        space=space_1,
+        meal_type=meal_type,
+        from_date=now + timedelta(days=2),
+        to_date=now + timedelta(days=2),
+        created_by=auth.get_user(u1_s1),
+    )
+    out_of_range = MealPlan.objects.create(
+        recipe=recipe_1_s1,
+        space=space_1,
+        meal_type=meal_type,
+        from_date=now + timedelta(days=10),
+        to_date=now + timedelta(days=11),
+        created_by=auth.get_user(u1_s1),
+    )
+
+    with scopes_disabled():
+        ShoppingListEntryFactory(
+            list_recipe=ShoppingListRecipeFactory(mealplan=in_range_1, space=space_1, created_by=auth.get_user(u1_s1)),
+            space=space_1,
+        )
+        ShoppingListEntryFactory(
+            list_recipe=ShoppingListRecipeFactory(mealplan=in_range_2, space=space_1, created_by=auth.get_user(u1_s1)),
+            space=space_1,
+        )
+        ShoppingListEntryFactory(
+            list_recipe=ShoppingListRecipeFactory(mealplan=out_of_range, space=space_1, created_by=auth.get_user(u1_s1)),
+            space=space_1,
+        )
+
+    r = u1_s1.post(
+        reverse(BULK_DELETE_URL),
+        {'from_date': from_dt.isoformat(), 'to_date': to_dt.isoformat()},
+        content_type='application/json',
+    )
+    assert r.status_code == 200
+
+    with scopes_disabled():
+        assert not MealPlan.objects.filter(id__in=[in_range_1.id, in_range_2.id]).exists()
+        assert MealPlan.objects.filter(id=out_of_range.id).exists()
+
+        assert not ShoppingListEntry.objects.filter(list_recipe__mealplan_id__in=[in_range_1.id, in_range_2.id]).exists()
+        assert ShoppingListEntry.objects.filter(list_recipe__mealplan_id=out_of_range.id).exists()
+
+
+def test_bulk_delete_invalid_payload_rejected(u1_s1):
+    r = u1_s1.post(
+        reverse(BULK_DELETE_URL),
+        {},
+        content_type='application/json',
+    )
+    assert r.status_code == 400

--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -102,7 +102,7 @@ from cookbook.serializer import (AccessTokenSerializer, AutomationSerializer, Au
                                  ExportLogSerializer, FoodInheritFieldSerializer, FoodSerializer,
                                  FoodShoppingUpdateSerializer, FoodSimpleSerializer, GroupSerializer,
                                  ImportLogSerializer, IngredientSerializer, IngredientSimpleSerializer,
-                                 InviteLinkSerializer, KeywordSerializer, MealPlanSerializer, MealTypeSerializer,
+                                 InviteLinkSerializer, KeywordSerializer, MealPlanSerializer, MealPlanBulkDeleteSerializer, MealTypeSerializer,
                                  PropertySerializer, PropertyTypeSerializer,
                                  RecipeBookEntrySerializer, RecipeBookSerializer, RecipeExportSerializer,
                                  RecipeFlatSerializer, RecipeFromSourceSerializer, RecipeImageSerializer,
@@ -1486,6 +1486,55 @@ class MealPlanViewSet(LoggingMixin, viewsets.ModelViewSet):
             # When using classes, DRF instantiates them.
             return [permission() for permission in permission_classes]
         return super().get_permissions()
+
+    @extend_schema(
+        request=MealPlanBulkDeleteSerializer,
+        responses={
+            200: OpenApiTypes.OBJECT,
+        },
+    )
+    @decorators.action(
+        detail=False,
+        methods=['POST'],
+        serializer_class=MealPlanBulkDeleteSerializer,
+        permission_classes=[(CustomIsOwner | CustomIsHousehold) & CustomTokenHasReadWriteScope],
+        url_path='bulk-delete',
+    )
+    def bulk_delete(self, request):
+        """
+        Delete multiple meal plans at once, by IDs and/or date range.
+        """
+        serializer = MealPlanBulkDeleteSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        ids = serializer.validated_data.get('ids') or []
+        from_date = serializer.validated_data.get('from_date')
+        to_date = serializer.validated_data.get('to_date')
+
+        queryset = self.get_queryset()
+
+        if ids:
+            queryset = queryset.filter(id__in=ids)
+
+        if from_date and to_date:
+            from_date_local = timezone.localdate(from_date)
+            to_date_local = timezone.localdate(to_date)
+            # Select meal plans whose date span overlaps the given range
+            queryset = queryset.filter(
+                from_date__date__lte=to_date_local,
+                to_date__date__gte=from_date_local,
+            )
+
+        mealplan_ids = list(queryset.values_list('id', flat=True))
+        deleted_count = queryset.count()
+        queryset.delete()
+
+        return Response(
+            {
+                'deleted': deleted_count,
+                'ids': mealplan_ids,
+            }
+        )
 
     @extend_schema(parameters=MealPlanViewQueryParameters,
                    responses={(200, 'text/calendar'): OpenApiTypes.STR})

--- a/vue3/src/components/display/MealPlanCalendarItem.vue
+++ b/vue3/src/components/display/MealPlanCalendarItem.vue
@@ -1,11 +1,21 @@
 <template>
-    <v-card class="card cv-item pa-0" hover
+    <v-card class="card cv-item pa-0 mealplan-card" hover
             :style="{'top': itemTop, 'height': itemHeight, 'border-color': mealPlan.mealType.color}"
             :draggable="true"
             :key="value.id"
             @dragstart="emit('onDragStart', value, $event)"
-            :class="value.classes">
+            :class="value.classes?.concat(selected ? ['mealplan-selected'] : [])">
         <v-card-text class="pa-0">
+            <v-checkbox
+                class="mealplan-selection-checkbox"
+                density="compact"
+                hide-details
+                color="primary"
+                :model-value="selected"
+                @click.stop
+                @mousedown.stop
+                @update:modelValue="(checked: boolean) => emit('toggleSelection', mealPlan.value, checked)"
+            />
             <div class="d-flex flex-row align-items-center">
                 <div class="flex-column" v-if="detailedItems">
                     <recipe-image :height="itemHeight" :width="itemHeight" :recipe="mealPlan.recipe"></recipe-image>
@@ -34,6 +44,9 @@ const emit = defineEmits({
     onDragStart: (value: IMealPlanNormalizedCalendarItem, event: DragEvent) => {
         return true
     },
+    toggleSelection: (value: MealPlan, selected: boolean) => {
+        return true
+    },
     delete: (value: MealPlan) => {
         return true
     }
@@ -43,7 +56,8 @@ let props = defineProps({
     value: {type: {} as PropType<IMealPlanNormalizedCalendarItem>, required: true},
     itemHeight: {type: String,},
     itemTop: {type: String,},
-    detailedItems: {type: Boolean, default: true}
+    detailedItems: {type: Boolean, default: true},
+    selected: {type: Boolean, default: false},
 })
 
 const mealPlan = computed(() => {
@@ -64,6 +78,21 @@ const itemTitle = computed(() => {
 </script>
 
 <style scoped>
+
+.mealplan-card {
+    position: relative;
+}
+
+.mealplan-selection-checkbox {
+    position: absolute;
+    top: 0.2rem;
+    left: 0.2rem;
+    z-index: 2;
+}
+
+.mealplan-selected {
+    background-color: rgba(33, 150, 243, 0.08);
+}
 
 .two-line-text {
     display: -webkit-box;

--- a/vue3/src/components/display/MealPlanView.vue
+++ b/vue3/src/components/display/MealPlanView.vue
@@ -3,7 +3,27 @@
         <v-col class="pb-0">
             <v-card class="h-100" :loading="useMealPlanStore().loading">
                 <!-- TODO add hint about CTRL key while drag/drop -->
-                <!-- TODO multi selection? date range selection ? -->
+                <v-toolbar flat density="compact" class="px-2">
+                    <v-btn
+                        color="primary"
+                        variant="elevated"
+                        :disabled="useMealPlanStore().selectedCount === 0"
+                        @click="useMealPlanStore().bulkDeleteSelected()"
+                    >
+                        {{ $t('Delete selected') }}
+                    </v-btn>
+                    <v-btn
+                        class="ml-2"
+                        variant="outlined"
+                        @click="useMealPlanStore().bulkDeleteDateRange(visibleRange.from, visibleRange.to)"
+                    >
+                        {{ $t('Clear visible range') }}
+                    </v-btn>
+                    <v-spacer></v-spacer>
+                    <span class="text-caption">
+                        {{ useMealPlanStore().selectedCount }} {{ $t('selected') }}
+                    </span>
+                </v-toolbar>
                 <calendar-view
                     :locale="locale"
                     :show-date="calendarDate"
@@ -28,6 +48,8 @@
                             :value="value"
                             :item-top="top"
                             @onDragStart="currentlyDraggedMealplan = value"
+                            :selected="useMealPlanStore().isSelected(value.mealPlan.id)"
+                            @toggleSelection="(mealPlan: MealPlan, checked: boolean) => useMealPlanStore().setSelected(mealPlan, checked)"
                             @delete="(arg: MealPlan) => {useMealPlanStore().plans.delete(arg.id)}"
                             :detailed-items="lgAndUp"
                         ></meal-plan-calendar-item>
@@ -96,6 +118,21 @@ const calendarItemHeight = computed(() => {
     } else {
         return '1.6rem'
     }
+})
+
+const visibleRange = computed(() => {
+    let daysInPeriod = 7
+    const displayPeriod = useUserPreferenceStore().deviceSettings.mealplan_displayPeriod
+    if (displayPeriod === 'month') {
+        daysInPeriod = 31
+    } else if (displayPeriod === 'year') {
+        daysInPeriod = 365
+    }
+
+    const days = useUserPreferenceStore().deviceSettings.mealplan_displayPeriodCount * daysInPeriod
+    const from = DateTime.fromJSDate(calendarDate.value).toJSDate()
+    const to = DateTime.fromJSDate(calendarDate.value).plus({days}).toJSDate()
+    return {from, to}
 })
 
 /**

--- a/vue3/src/openapi/apis/ApiApi.ts
+++ b/vue3/src/openapi/apis/ApiApi.ts
@@ -1540,6 +1540,17 @@ export interface ApiMealPlanListRequest {
     toDate?: string;
 }
 
+export interface ApiMealPlanBulkDeleteRequest {
+    ids?: Array<number>;
+    fromDate?: string;
+    toDate?: string;
+}
+
+export interface MealPlanBulkDeleteResponse {
+    deleted?: number;
+    ids?: Array<number>;
+}
+
 export interface ApiMealPlanPartialUpdateRequest {
     id: number;
     patchedMealPlan?: Omit<PatchedMealPlan, 'noteMarkdown'|'createdBy'|'recipeName'|'mealTypeName'|'shopping'>;
@@ -10914,6 +10925,50 @@ export class ApiApi extends runtime.BaseAPI {
      */
     async apiMealPlanList(requestParameters: ApiMealPlanListRequest = {}, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<PaginatedMealPlanList> {
         const response = await this.apiMealPlanListRaw(requestParameters, initOverrides);
+        return await response.value();
+    }
+
+    /**
+     * Delete multiple meal plan entries at once by IDs and/or date range.
+     */
+    async apiMealPlanBulkDeleteRaw(requestParameters: ApiMealPlanBulkDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<runtime.ApiResponse<MealPlanBulkDeleteResponse>> {
+        const queryParameters: any = {};
+
+        const headerParameters: runtime.HTTPHeaders = {};
+
+        headerParameters['Content-Type'] = 'application/json';
+
+        if (this.configuration && this.configuration.apiKey) {
+            headerParameters["Authorization"] = await this.configuration.apiKey("Authorization"); // ApiKeyAuth authentication
+        }
+
+        const body: any = {};
+        if (requestParameters['ids'] != null) {
+            body['ids'] = requestParameters['ids'];
+        }
+        if (requestParameters['fromDate'] != null) {
+            body['from_date'] = requestParameters['fromDate'];
+        }
+        if (requestParameters['toDate'] != null) {
+            body['to_date'] = requestParameters['toDate'];
+        }
+
+        const response = await this.request({
+            path: `/api/meal-plan/bulk-delete/`,
+            method: 'POST',
+            headers: headerParameters,
+            query: queryParameters,
+            body: body,
+        }, initOverrides);
+
+        return new runtime.JSONApiResponse<MealPlanBulkDeleteResponse>(response, (jsonValue) => jsonValue as MealPlanBulkDeleteResponse);
+    }
+
+    /**
+     * Delete multiple meal plan entries at once by IDs and/or date range.
+     */
+    async apiMealPlanBulkDelete(requestParameters: ApiMealPlanBulkDeleteRequest, initOverrides?: RequestInit | runtime.InitOverrideFunction): Promise<MealPlanBulkDeleteResponse> {
+        const response = await this.apiMealPlanBulkDeleteRaw(requestParameters, initOverrides);
         return await response.value();
     }
 

--- a/vue3/src/stores/MealPlanStore.ts
+++ b/vue3/src/stores/MealPlanStore.ts
@@ -12,6 +12,7 @@ const _LOCAL_STORAGE_KEY = "MEAL_PLAN_CLIENT_SETTINGS"
 export const useMealPlanStore = defineStore(_STORE_ID, () => {
 
     let plans = ref(new Map<number, MealPlan>)
+    const selectedIds = ref(new Set<number>())
     let currently_updating = ref([new Date(0), new Date(0)])
     const loading = ref(false)
     let settings = ref({})
@@ -28,6 +29,38 @@ export const useMealPlanStore = defineStore(_STORE_ID, () => {
 
         return plan_list
     })
+
+    const selectedCount = computed(() => selectedIds.value.size)
+
+    function isSelected(id: number | undefined) {
+        return id !== undefined && selectedIds.value.has(id)
+    }
+
+    function setSelected(object: MealPlan, selected: boolean) {
+        if (object.id == undefined) {
+            return
+        }
+        if (selected) {
+            selectedIds.value.add(object.id)
+        } else {
+            selectedIds.value.delete(object.id)
+        }
+    }
+
+    function toggleSelection(object: MealPlan) {
+        if (object.id == undefined) {
+            return
+        }
+        if (selectedIds.value.has(object.id)) {
+            selectedIds.value.delete(object.id)
+        } else {
+            selectedIds.value.add(object.id)
+        }
+    }
+
+    function clearSelection() {
+        selectedIds.value.clear()
+    }
 
     const empty_meal_plan = computed(() => {
         return {
@@ -67,6 +100,7 @@ export const useMealPlanStore = defineStore(_STORE_ID, () => {
             currently_updating.value = [from_date, to_date] // certainly no perfect check but better than nothing
             loading.value = true
             plans.value = new Map<number, MealPlan>()
+            selectedIds.value.clear()
             return recLoadMealPlans(from_date, to_date)
         }
         return new Promise(() => {
@@ -142,6 +176,61 @@ export const useMealPlanStore = defineStore(_STORE_ID, () => {
         })
     }
 
+    function _mealPlanOverlapsRange(mp: MealPlan, rangeStart: DateTime, rangeEnd: DateTime): boolean {
+        const mpStart = DateTime.fromJSDate(mp.fromDate).toLocal().startOf('day')
+        const mpEnd = mp.toDate ? DateTime.fromJSDate(mp.toDate).toLocal().startOf('day') : mpStart
+        return mpStart <= rangeEnd && mpEnd >= rangeStart
+    }
+
+    function bulkDeleteSelected() {
+        const idsToDelete = Array.from(selectedIds.value)
+        if (idsToDelete.length === 0) {
+            return
+        }
+
+        const api = new ApiApi()
+        loading.value = true
+
+        return api.apiMealPlanBulkDelete({ids: idsToDelete}).then((r) => {
+            useMessageStore().addPreparedMessage(PreparedMessage.DELETE_SUCCESS, r)
+            idsToDelete.forEach((id) => plans.value.delete(id))
+            clearSelection()
+        }).catch((err) => {
+            useMessageStore().addError(ErrorMessageType.DELETE_ERROR, err)
+        }).finally(() => {
+            loading.value = false
+        })
+    }
+
+    function bulkDeleteDateRange(fromDate: Date, toDate: Date) {
+        const api = new ApiApi()
+        loading.value = true
+
+        const rangeStart = DateTime.fromJSDate(fromDate).toLocal().startOf('day')
+        const rangeEnd = DateTime.fromJSDate(toDate).toLocal().startOf('day')
+
+        const requestFrom = rangeStart.toISO()
+        const requestTo = rangeEnd.toISO()
+
+        return api.apiMealPlanBulkDelete({fromDate: requestFrom as string, toDate: requestTo as string}).then((r) => {
+            // Optimistically remove overlapping meal plans from the local cache
+            const idsToDelete: number[] = []
+            plans.value.forEach((mp: MealPlan, id: number) => {
+                if (_mealPlanOverlapsRange(mp, rangeStart, rangeEnd)) {
+                    idsToDelete.push(id)
+                }
+            })
+
+            idsToDelete.forEach((id) => plans.value.delete(id))
+            clearSelection()
+            useMessageStore().addPreparedMessage(PreparedMessage.DELETE_SUCCESS, r)
+        }).catch((err) => {
+            useMessageStore().addError(ErrorMessageType.DELETE_ERROR, err)
+        }).finally(() => {
+            loading.value = false
+        })
+    }
+
     // function updateClientSettings(settings) {
     //     this.settings = settings
     //     localStorage.setItem(_LOCAL_STORAGE_KEY, JSON.stringify(this.settings))
@@ -160,7 +249,26 @@ export const useMealPlanStore = defineStore(_STORE_ID, () => {
     //         return JSON.parse(s)
     //     }
     // }
-    return {plans, currently_updating, planList, loading, refreshFromAPI, createObject, updateObject, deleteObject, refreshLastUpdatedPeriod, createOrUpdate}
+    return {
+        plans,
+        selectedIds,
+        currently_updating,
+        planList,
+        selectedCount,
+        loading,
+        refreshFromAPI,
+        createObject,
+        updateObject,
+        deleteObject,
+        refreshLastUpdatedPeriod,
+        createOrUpdate,
+        isSelected,
+        setSelected,
+        toggleSelection,
+        clearSelection,
+        bulkDeleteSelected,
+        bulkDeleteDateRange,
+    }
 })
 
 // enable hot reload for store


### PR DESCRIPTION
## Backend
- Added `MealPlanBulkDeleteSerializer` in `cookbook/serializer.py` to accept:
  - `ids` (list of meal plan IDs), and/or
  - `from_date` + `to_date` (overlapping date range deletion)
- Added a new `bulk_delete` action to `MealPlanViewSet` in `cookbook/views/api.py` exposed as:
  - `POST /api/meal-plan/bulk-delete/`
- Bulk deletion uses the existing `MealPlanViewSet.get_queryset()` filtering to enforce:
  - space scoping
  - ownership/household permissions
- Deleting meal plans cascades/removes dependent shopping data (linked shopping list recipes/entries).

## Frontend
- Added multi-selection UX to the meal plan calendar:
  - `vue3/src/components/display/MealPlanView.vue`
  - `vue3/src/components/display/MealPlanCalendarItem.vue`
- Added Pinia store selection state + bulk actions:
  - `vue3/src/stores/MealPlanStore.ts`
  - `bulkDeleteSelected()` calls the new endpoint to delete selected entries
  - `bulkDeleteDateRange()` calls the new endpoint to clear overlapping entries in the visible range
- Added typed client helper for the new endpoint:
  - `vue3/src/openapi/apis/ApiApi.ts`

## Tests
- Added API test coverage in `cookbook/tests/api/test_api_meal_plan.py`:
  - bulk delete by `ids`
  - bulk delete by date range (overlap behavior)
  - invalid payload validation (expects `400`)
  - asserts that linked shopping entries are removed for deleted meal plans

## Verification
- `pytest -q cookbook/tests/api/test_api_meal_plan.py`
- `cd vue3 && npx vue-tsc --noEmit`
- `cd vue3 && yarn build`