### PR TITLE
add missing required=False on InviteLinkSerializer household field

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1802,7 +1802,7 @@ class InventoryLogSerializer(SpacedModelSerializer):
 
 class InviteLinkSerializer(WritableNestedModelSerializer):
     group = GroupSerializer()
-    household = HouseholdSerializer()
+    household = HouseholdSerializer(allow_null=True, required=False)
     email_sent = serializers.SerializerMethodField()
 
     @extend_schema_field(bool)


### PR DESCRIPTION
  Fixes 7 failing tests in `test_api_invitelinke.py`.

    - Add `allow_null=True, required=False` to household field on InviteLinkSerializer