### PR TITLE
fix: invalid response code in apiRecipeShoppingUpdate

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -1878,7 +1878,7 @@ class RecipeViewSet(LoggingMixin, viewsets.ModelViewSet, DeleteRelationMixing):
             http_status = status.HTTP_500_INTERNAL_SERVER_ERROR
         else:
             content = {'msg': _(f'{obj.name} was added to the shopping list.')}
-            http_status = status.HTTP_204_NO_CONTENT
+            http_status = status.HTTP_200_OK
 
         return Response(content, status=http_status)
 


### PR DESCRIPTION
This fixes the incorrect 204 NO_CONTENT response, where a content is given in apiRecipeShoppingUpdate.

Since the API schema also specifies a 200 OK code this should be used.
