### PR TITLE
fix: 403 on form login

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -46,6 +46,24 @@ Navigate to `/system/` and review the headers listed in the DEBUG section.  At a
 | HTTP_X_SCRIPT_NAME:/subfolder      | If you are hosting Tandoor at a subfolder instead of a subdomain this header must exist. |
 
 
+## Why am I getting a 403 error when trying to log in?
+
+Starting with version 2.6.1, Tandoor includes login rate limiting to protect against brute-force attacks.
+This requires Tandoor to determine your client IP address from the `X-Forwarded-For` header set by
+reverse proxies in front of the application.
+
+Tandoor's built-in nginx is always counted as one trusted proxy, so the default setting of
+`ALLAUTH_TRUSTED_PROXY_COUNT=1` works for most setups. If you are running additional reverse proxies
+(Traefik, Caddy, nginx proxy manager, etc.) and experience 403 errors on login, increase this value
+to match your total number of proxies (including Tandoor's built-in nginx).
+
+For example, if you run one external reverse proxy in front of Tandoor:
+```
+ALLAUTH_TRUSTED_PROXY_COUNT=2
+```
+
+See the [configuration docs](system/configuration.md#trusted-proxy-count) for more details.
+
 ## Why am I getting CSRF Errors?
 If you are getting CSRF Errors this is most likely due to a reverse proxy not passing the correct headers.
 

--- a/docs/system/configuration.md
+++ b/docs/system/configuration.md
@@ -395,6 +395,29 @@ SOCIALACCOUNT_PROVIDERS='{"openid_connect":{"APPS":[{"provider_id":"myidp","name
 | `SOCIALACCOUNT_EMAIL_AUTHENTICATION` | `0` | Match social logins to existing accounts by email ([details](../features/authentication.md#email-based-account-matching)) |
 | `SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT` | `0` | Skip email verification when matching ([details](../features/authentication.md#email-based-account-matching)) |
 
+#### Trusted Proxy Count
+
+> default `1`
+
+Tandoor uses IP-based rate limiting on login, signup, and password reset to prevent brute-force attacks.
+Because Tandoor's built-in nginx proxies to the application server via a unix socket, the application
+cannot see client IP addresses directly and must read them from the `X-Forwarded-For` header.
+
+This setting tells Tandoor how many reverse proxies sit between the client and the application server.
+The default value of `1` accounts for Tandoor's built-in nginx and works for most deployments. If you
+run additional reverse proxies, increase this value to match your total proxy count so that rate limiting
+uses the real client IP instead of a proxy IP.
+
+| Setup | Value |
+| :--- | :--- |
+| Direct access (no external proxy) | `1` |
+| One external reverse proxy | `2` |
+| Two external reverse proxies (e.g. CDN + local proxy) | `3` |
+
+```
+ALLAUTH_TRUSTED_PROXY_COUNT=1
+```
+
 #### Remote User Auth
 > default `0` - options `0`, `1`
 

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -702,6 +702,7 @@ SOCIALACCOUNT_FORMS = {
 }
 
 ACCOUNT_EMAIL_UNKNOWN_ACCOUNTS = False
+ALLAUTH_TRUSTED_PROXY_COUNT = int(os.getenv('ALLAUTH_TRUSTED_PROXY_COUNT', 1))
 ACCOUNT_RATE_LIMITS = {
     "change_password": "1/m/user",
     "reset_password": "1/m/ip,1/m/key",


### PR DESCRIPTION
  Resolves #4555
    - Add ALLAUTH_TRUSTED_PROXY_COUNT setting (default 1)
    - Add FAQ entry for 403 login errors
    - Document Trusted Proxy Count in configuration docs