### PR TITLE
Feature/pestle import

### DIFF
--- a/cookbook/forms.py
+++ b/cookbook/forms.py
@@ -53,6 +53,7 @@ class ImportExportBase(forms.Form):
     REZEPTSUITEDE = 'REZEPTSUITEDE'
     PDF = 'PDF'  # Deprecated: pyppeteer removed, kept for DB/migration compat
     GOURMET = 'GOURMET'
+    PESTLE = 'PESTLE'
 
     type = forms.ChoiceField(
         choices=((DEFAULT, _('Default')), (PAPRIKA, 'Paprika'), (NEXTCLOUD, 'Nextcloud Cookbook'), (MEALIE, 'Mealie'), (MEALIE1, 'Mealie1'), (CHOWDOWN, 'Chowdown'),
@@ -60,7 +61,7 @@ class ImportExportBase(forms.Form):
                  (MEALMASTER, 'MealMaster'), (REZKONV, 'RezKonv'), (OPENEATS, 'Openeats'), (RECIPEKEEPER, 'Recipe Keeper'), (PLANTOEAT, 'Plantoeat'), (COOKBOOKAPP, 'CookBookApp'),
                  # (COOKLANG, 'Cooklang Markdown'), (COPYMETHAT, 'CopyMeThat'), (PDF, 'PDF'), (MELARECIPES, 'Melarecipes'), (COOKMATE, 'Cookmate'),
                  (COOKLANG, 'Cooklang Markdown'), (COPYMETHAT, 'CopyMeThat'), (MELARECIPES, 'Melarecipes'), (COOKMATE, 'Cookmate'),
-                 (REZEPTSUITEDE, 'Recipesuite.de'), (GOURMET, 'Gourmet'))
+                 (REZEPTSUITEDE, 'Recipesuite.de'), (GOURMET, 'Gourmet'), (PESTLE, 'Pestle'))
     )
 
 

--- a/cookbook/integration/integration.py
+++ b/cookbook/integration/integration.py
@@ -227,7 +227,7 @@ class Integration:
                                     fn = "" if not hasattr(z, 'filename') else f'IMPORTING {z.filename}'
                                     self.handle_exception(e, log=il, message=f'-------------------- \nERROR {fn}\n{e}\n--------------------\n')
                         import_zip.close()
-                    elif '.json' in f['name'] or '.xml' in f['name'] or '.txt' in f['name'] or '.mmf' in f['name'] or '.rk' in f['name'] or '.melarecipe' in f['name']:
+                    elif '.json' in f['name'] or '.xml' in f['name'] or '.txt' in f['name'] or '.mmf' in f['name'] or '.rk' in f['name'] or '.melarecipe' in f['name'] or '.pestle' in f['name']:
                         data_list = self.split_recipe_file(f['file'])
                         il.total_recipes += len(data_list)
                         for d in data_list:

--- a/cookbook/integration/pestle.py
+++ b/cookbook/integration/pestle.py
@@ -106,7 +106,7 @@ class Pestle(Integration):
             if "@type" not in s or s["@type"] == 1 or s["@type"] == 2:
                 step = Step.objects.create(
                     instruction=s["text"],
-                    name=_("Step") + " " + {index + 1},
+                    name=_("Step") + " " + str(index + 1),
                     space=self.request.space,
                     show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
                 )

--- a/cookbook/integration/pestle.py
+++ b/cookbook/integration/pestle.py
@@ -37,14 +37,14 @@ class Pestle(Integration):
             description=description,
             created_by=self.request.user,
             internal=True,
-            servings=(parse_servings(recipe_dict.get("recipeYield", 1))),
+            servings=(parse_servings(recipe_dict["recipeYield"]) if "recipeYield" in recipe_dict else 1),
             space=self.request.space,
         )
 
-        total_time = (iso_duration_to_minutes(recipe_dict.get("totalTime", 0)))
-        prep_time = (iso_duration_to_minutes(recipe_dict.get("prepTime", 0)))
+        total_time = (iso_duration_to_minutes(recipe_dict["totalTime"]) if "totalTime" in recipe_dict and recipe_dict["totalTime"] != "" else 0)
+        prep_time = (iso_duration_to_minutes(recipe_dict["prepTime"]) if "prepTime" in recipe_dict and recipe_dict["prepTime"] != "" else 0)
 
-        recipe.waiting_time = (iso_duration_to_minutes(recipe_dict.get("cookTime", 0)))
+        recipe.waiting_time = (iso_duration_to_minutes(recipe_dict["cookTime"]) if "cookTime" in recipe_dict and recipe_dict["cookTime"] != "" else 0)
         recipe.working_time = (prep_time if prep_time > 0 else total_time - recipe.waiting_time)
         if "source" in recipe_dict:
             recipe.source_url = recipe_dict["source"].strip()

--- a/cookbook/integration/pestle.py
+++ b/cookbook/integration/pestle.py
@@ -37,15 +37,14 @@ class Pestle(Integration):
             description=description,
             created_by=self.request.user,
             internal=True,
-            servings=(parse_servings(recipe_dict["recipeYield"]) if "recipeYield" in recipe_dict else 1),
+            servings=(parse_servings(recipe_dict.get("recipeYield", 1))),
             space=self.request.space,
         )
 
-        total_time = (iso_duration_to_minutes(recipe_dict["totalTime"]) if "totalTime" in recipe_dict else 0)
+        total_time = (iso_duration_to_minutes(recipe_dict.get("totalTime", 0)))
+        prep_time = (iso_duration_to_minutes(recipe_dict.get("prepTime", 0)))
 
-        prep_time = (iso_duration_to_minutes(recipe_dict["prepTime"]) if ("prepTime" in recipe_dict) else 0)
-
-        recipe.waiting_time = (iso_duration_to_minutes(recipe_dict["cookTime"]) if "cookTime" in recipe_dict else 0)
+        recipe.waiting_time = (iso_duration_to_minutes(recipe_dict.get("cookTime", 0)))
         recipe.working_time = (prep_time if prep_time > 0 else total_time - recipe.waiting_time)
         if "source" in recipe_dict:
             recipe.source_url = recipe_dict["source"].strip()
@@ -122,6 +121,7 @@ class Pestle(Integration):
                     space=self.request.space,
                     show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
                 )
+                recipe.show_ingredient_overview = False
             recipe.steps.add(step)
 
         if "nutrition" in recipe_dict:

--- a/cookbook/integration/pestle.py
+++ b/cookbook/integration/pestle.py
@@ -70,7 +70,21 @@ class Pestle(Integration):
                 space=self.request.space,
                 show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
             )
+
             for ingredient in recipe_dict["recipeIngredient"]:
+                if ":" in ingredient["text"] and ingredient_step.ingredients.count() == 0:
+                    ingredient_step.name = _("Ingredients") + " " + ingredient["text"]
+                    ingredient_step.save()
+                    continue
+                elif ":" in ingredient["text"] and ingredient_step.ingredients.count() > 0:
+                    recipe.steps.add(ingredient_step)
+                    ingredient_step = Step.objects.create(
+                        name=_("Ingredients") + " " + ingredient["text"],
+                        space=self.request.space,
+                        show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
+                    )
+                    continue
+
                 ingredient_parser = IngredientParser(self.request, True)
                 if "quantity" in ingredient and "name" in ingredient:
                     ingredient_step.ingredients.add(

--- a/cookbook/integration/pestle.py
+++ b/cookbook/integration/pestle.py
@@ -1,0 +1,155 @@
+from io import BytesIO
+from django.utils.translation import gettext as _
+import re
+
+import json
+
+import requests
+
+from cookbook.helper.ingredient_parser import IngredientParser
+from cookbook.helper.recipe_url_import import (
+    parse_servings,
+    iso_duration_to_minutes,
+)
+from cookbook.integration.integration import Integration
+from cookbook.models import Ingredient, NutritionInformation, Recipe, Step, Keyword
+
+
+class Pestle(Integration):
+
+    def split_recipe_file(self, file) -> list[str]:
+        encoding = "utf-8"
+        byte_string = file.read()
+        text_obj = byte_string.decode(encoding, errors="ignore")
+        json_export = json.loads(text_obj)
+        return json_export
+
+    def get_recipe_from_file(self, file):
+
+        recipe_dict: dict = file
+
+        description = ""
+        if "description" in recipe_dict:
+            description = ("" if len(recipe_dict["description"].strip()) > 500 else recipe_dict["description"].strip())
+
+        recipe = Recipe.objects.create(
+            name=recipe_dict["name"].strip(),
+            description=description,
+            created_by=self.request.user,
+            internal=True,
+            servings=(parse_servings(recipe_dict["recipeYield"]) if "recipeYield" in recipe_dict else 1),
+            space=self.request.space,
+        )
+
+        total_time = (iso_duration_to_minutes(recipe_dict["totalTime"]) if "totalTime" in recipe_dict else 0)
+
+        prep_time = (iso_duration_to_minutes(recipe_dict["prepTime"]) if ("prepTime" in recipe_dict) else 0)
+
+        recipe.waiting_time = (iso_duration_to_minutes(recipe_dict["cookTime"]) if "cookTime" in recipe_dict else 0)
+        recipe.working_time = (prep_time if prep_time > 0 else total_time - recipe.waiting_time)
+        if "source" in recipe_dict:
+            recipe.source_url = recipe_dict["source"].strip()
+
+        if "recipeCategory" in recipe_dict and len(recipe_dict["recipeCategory"]) > 0:
+            recipe.keywords.add(Keyword.objects.get_or_create(
+                space=self.request.space,
+                name=recipe_dict["recipeCategory"][0].capitalize(),
+            )[0])
+
+        if "keywords" in recipe_dict and len(recipe_dict["keywords"]) > 0:
+            for key in recipe_dict["keywords"]:
+
+                if "," in key:
+                    for x in key.split(","):
+                        recipe.keywords.add(Keyword.objects.get_or_create(space=self.request.space, name=x)[0])
+                else:
+                    recipe.keywords.add(Keyword.objects.get_or_create(space=self.request.space, name=key)[0])
+
+        if ("recipeIngredient" in recipe_dict and len(recipe_dict["recipeIngredient"]) > 0):
+            ingredient_step = Step.objects.create(
+                name=_("Ingredients"),
+                space=self.request.space,
+                show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
+            )
+            for ingredient in recipe_dict["recipeIngredient"]:
+                ingredient_parser = IngredientParser(self.request, True)
+                if "quantity" in ingredient and "name" in ingredient:
+                    ingredient_step.ingredients.add(
+                        Ingredient.objects.create(
+                            food=ingredient_parser.get_food(ingredient["name"]),
+                            unit=(ingredient_parser.get_unit(ingredient["unit"]) if "unit" in ingredient else None),
+                            amount=ingredient["quantity"],
+                            original_text=ingredient["text"],
+                            space=self.request.space,
+                        )
+                    )
+                else:
+                    amount, unit, food, note = ingredient_parser.parse(ingredient["text"])
+                    f = ingredient_parser.get_food(food)
+                    u = ingredient_parser.get_unit(unit)
+                    ingredient_step.ingredients.add(Ingredient.objects.create(
+                        food=f,
+                        unit=u,
+                        amount=amount,
+                        original_text=ingredient["text"],
+                        space=self.request.space,
+                    ))
+            recipe.steps.add(ingredient_step)
+
+        instructions = recipe_dict["recipeInstructions"]
+
+        # Ignore recipe sections if only one exists
+        if len(instructions) == 1 and instructions[0]["@type"] == 0:
+            instructions = instructions[0]["itemListElement"]
+
+        for index, s in enumerate(instructions):
+            if "@type" not in s or s["@type"] == 1 or s["@type"] == 2:
+                step = Step.objects.create(
+                    instruction=s["text"],
+                    name=_("Step") + " " + {index + 1},
+                    space=self.request.space,
+                    show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
+                )
+            # Handle Pestle Sections
+            elif s["@type"] == 0:
+                steps = []
+                for item in s["itemListElement"]:
+                    steps.append(item["text"])
+                steps = [f"{i+1}. {text}\n" for i, text in enumerate(steps)]
+                step = Step.objects.create(
+                    instruction="\n".join(steps),
+                    name=s["name"],
+                    space=self.request.space,
+                    show_ingredients_table=self.request.user.userpreference.show_step_ingredients,
+                )
+            recipe.steps.add(step)
+
+        if "nutrition" in recipe_dict:
+            nutrition = {}
+            if recipe_dict["nutrition"]["calories"] is not None:
+                nutrition["calories"] = int(re.search(r"\d+", recipe_dict["nutrition"]["calories"]).group())
+            if recipe_dict["nutrition"]["proteinContent"] is not None:
+                nutrition["proteins"] = int(re.search(r"\d+", recipe_dict["nutrition"]["proteinContent"]).group())
+            if recipe_dict["nutrition"]["fatContent"] is not None:
+                nutrition["fats"] = int(re.search(r"\d+", recipe_dict["nutrition"]["fatContent"]).group())
+            if recipe_dict["nutrition"]["carbohydrateContent"] is not None:
+                nutrition["carbohydrates"] = int(re.search(r"\d+", recipe_dict["nutrition"]["carbohydrateContent"]).group())
+
+            if nutrition != {}:
+                recipe.nutrition = NutritionInformation.objects.create(**nutrition, space=self.request.space)
+                recipe.save()
+
+        if "image" in recipe_dict and len(recipe_dict["image"]) > 0:
+            response = requests.get(recipe_dict["image"][0]["url"])
+            if response.ok and response.content:
+                self.import_recipe_image(
+                    recipe,
+                    BytesIO(response.content),
+                )
+        return recipe
+
+    def get_files_from_recipes(self, recipes, el, cookie):
+        raise NotImplementedError("Method not implemented in storage integration")
+
+    def get_file_from_recipe(self, recipe):
+        raise NotImplementedError("Method not implemented in storage integration")

--- a/cookbook/views/import_export.py
+++ b/cookbook/views/import_export.py
@@ -27,6 +27,7 @@ from cookbook.integration.openeats import OpenEats
 from cookbook.integration.paprika import Paprika
 # from cookbook.integration.pdfexport import PDFexport  # pyppeteer dependency removed
 from cookbook.integration.pepperplate import Pepperplate
+from cookbook.integration.pestle import Pestle
 from cookbook.integration.plantoeat import Plantoeat
 from cookbook.integration.recettetek import RecetteTek
 from cookbook.integration.recipekeeper import RecipeKeeper
@@ -90,6 +91,8 @@ def get_integration(request, export_type):
         return Rezeptsuitede(request, export_type)
     if export_type == ImportExportBase.GOURMET:
         return Gourmet(request, export_type)
+    if export_type == ImportExportBase.PESTLE:
+        return Pestle(request, export_type)
 
 
 @group_required('user')

--- a/docs/features/import_export.md
+++ b/docs/features/import_export.md
@@ -44,6 +44,7 @@ Overview of the capabilities of the different integrations.
 | Cookmate           | ✔️     | ⌚     | ✔️     |
 | PDF (experimental) | ⌚️     | ✔️     | ✔️     |
 | Gourmet            | ✔️     | ❌     | ✔️     |
+| Pestle             | ✔️     | ❌     | ✔️     |
 
 
 ✔️ = implemented, ❌ = not implemented and not possible/planned, ⌚ = not yet implemented
@@ -302,3 +303,14 @@ To generate the file, export to HTML in Gourmet and zip the generated folder.
 The import of menus is not supported.
 
 Export is not supported due to problems with the `.grmt` format.
+
+## Pestle 
+
+An importer for your [Pestle](https://pestlechef.app/) recipe collection. To use it, navigate to the settings in the Pestle app, click on "Export" and select "Pestle Recipe Format". You will get a file called `mm-dd-yyyy.pestle` which you can use for the import.
+
+If available the following information will be imported: Name, Description, Servings, Waiting time, Working time, Category (keyword), Keywords, Ingredients (as extra step), Instructions, Nutrition, Image and Source.
+
+> [!WARNING]
+> Other fields like: Rating, Author, Notes, Cuisine or Video will be lost.
+
+Export is not supported because Pestle needs image URLs which are not included in the import.

--- a/vue3/src/utils/integration_utils.ts
+++ b/vue3/src/utils/integration_utils.ts
@@ -34,4 +34,5 @@ export const INTEGRATIONS: Array<Integration> = [
     {id: 'SAFFRON', name: "Saffron", import: true, export: true, helpUrl: 'https://docs.tandoor.dev/features/import_export/#safron'},
     {id: 'REZEPTSUITEDE', name: "Rezeptsuite.de", import: true, export: false, helpUrl: 'https://docs.tandoor.dev/features/import_export/#rezeptsuitede'},
     {id: 'GOURMET', name: "Gourmet", import: true, export: false, helpUrl: 'https://docs.tandoor.dev/features/import_export/#gourmet'},
+    {id: 'PESTLE', name: "Pestle", import: true, export: false, helpUrl: 'https://docs.tandoor.dev/features/import_export/#pestle'},
 ]


### PR DESCRIPTION
This PR resolves #4571 Import from Pestle.

## Todo

- [x] Update documentation
- [x] Handle ingredient sections

## Working

- Name
- Description
- Servings
- Waiting Time (see note)
- Working Time (see note)
- Category (as keyword)
- Keywords
- Ingriedients (stored in an extra "ingredient"-step)
- Instructions (see 2nd note)
- Nutrition
- Image

> [!NOTE] 
> Pestle has the equivalents `cookTime`, `prepTime` and `totalTime`. `cookTime` is mapped to `waiting time` and `prepTime` is mapped to `working time` if it is not 0. Otherwise `working time' is calculated by subtracting `waiting time` from `totalTime`.

> [!NOTE] 
> Pestle supports sections to seperate instructions. In case a recipe uses that feature, all instructions in that section will be written as numbered list into one "section"-step

## Not sure how to do in Tandoor

- Rating
- Notes
