### PR TITLE
feat: add support for richer reverse proxy auth and custom logout URL

### DIFF
--- a/recipes/middleware.py
+++ b/recipes/middleware.py
@@ -7,6 +7,31 @@ from django.db import connection
 
 class CustomRemoteUser(RemoteUserMiddleware):
     header = getenv('PROXY_HEADER', 'HTTP_REMOTE_USER')
+    
+    # Add this method to capture extra headers
+    def process_request(self, request):
+        if not settings.REMOTE_USER_AUTH:
+            return
+            
+        # Standard Django RemoteUserMiddleware logic
+        super().process_request(request)
+        
+        # If user is authenticated, sync the new fields
+        if request.user.is_authenticated:
+            email = request.META.get('HTTP_REMOTE_EMAIL')
+            name = request.META.get('HTTP_REMOTE_NAME')
+            
+            updated = False
+            if email and request.user.email != email:
+                request.user.email = email
+                updated = True
+            if name and request.user.first_name != name:
+                request.user.first_name = name
+                updated = True
+            
+            if updated:
+                request.user.save()
+
 
 
 """

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -21,6 +21,7 @@ import traceback
 from django.contrib import messages
 from django.utils.translation import gettext_lazy as _
 from dotenv import load_dotenv
+from os import getenv
 
 
 def extract_bool(env_key, default):
@@ -722,3 +723,9 @@ EXTERNAL_CONNECTORS_QUEUE_SIZE = int(os.getenv('EXTERNAL_CONNECTORS_QUEUE_SIZE',
 
 mimetypes.add_type("text/javascript", ".js", True)
 mimetypes.add_type("text/javascript", ".mjs", True)
+
+
+
+# The URL to redirect users to after logging out when using a reverse proxy.
+#If not set , the default internal logout flow is used.
+REVERSE_PROXY_AUTH_LOGOUT = getenv('REVERSE_PROXY_AUTH_LOGOUT', None)


### PR DESCRIPTION
This PR addresses issue #1134 by extending the reverse proxy authentication capabilities and allowing for a custom logout redirect.
Changes:
User Data Sync: Update middleware.py to support HTTP_REMOTE_NAME and HTTP_REMOTE_EMAIL headers. The user's name and email are now automatically updated in the database upon login if these headers are present.

Custom Logout: Added a new environment variable REVERSE_PROXY_AUTH_LOGOUT in settings.py.

Frontend Update: Modified the logout logic to redirect to the custom SSO logout URL if the environment variable is set , preventing the hardcoded redirect to the internal login page.

Fixes: #1134