### PR TITLE
🐛 fix: sort homepage meal plan entries by meal type start time

### DIFF
--- a/vue3/src/components/display/HorizontalMealPlanWindow.vue
+++ b/vue3/src/components/display/HorizontalMealPlanWindow.vue
@@ -120,9 +120,13 @@ const meal_plan_grid = computed(() => {
             DateTime.fromJSDate(m.toDate != undefined ? m.toDate : m.fromDate).startOf("day") >= grid_day_date.startOf("day")
         )
         .sort((a: MealPlan, b: MealPlan) => {
-          const timeA = a.mealType?.time ?? "￿"
-          const timeB = b.mealType?.time ?? "￿"
-          if (timeA !== timeB) return timeA < timeB ? -1 : 1
+          const timeA = a.mealType?.time
+          const timeB = b.mealType?.time
+          if (timeA !== timeB) {
+            if (timeA == null) return 1
+            if (timeB == null) return -1
+            return timeA < timeB ? -1 : 1
+          }
           return (a.mealType?.order ?? 0) - (b.mealType?.order ?? 0)
         }),
     } as MealPlanGridItem)

--- a/vue3/src/components/display/HorizontalMealPlanWindow.vue
+++ b/vue3/src/components/display/HorizontalMealPlanWindow.vue
@@ -1,164 +1,173 @@
 <template>
-    <!--    <v-row justify="space-between">-->
-    <!--        <v-col>-->
-    <!--            <h2><i class="fas fa-calendar-week fa-fw"></i> Meal Plans</h2>-->
-    <!--        </v-col>-->
-    <!--    </v-row>-->
+  <!--    <v-row justify="space-between">-->
+  <!--        <v-col>-->
+  <!--            <h2><i class="fas fa-calendar-week fa-fw"></i> Meal Plans</h2>-->
+  <!--        </v-col>-->
+  <!--    </v-row>-->
 
-    <v-row class="mt-0" v-if="mealPlanWindows.length > 0">
-        <v-col>
-            <v-window v-model="currentWindowIndex">
-                <v-window-item v-for="(w, i) in mealPlanWindows" :value="i" class="pt-1 pb-1">
-                    <v-row>
-                        <v-col v-for="mealPlanGridItem in w">
-
-                            <v-list density="compact" class="pt-0 pb-0">
-                                <v-list-item class="text-center">
-                                    <div class="d-flex ">
-                                        <div class="flex-col align-self-start">
-                                            <v-btn @click="currentWindowIndex--" v-if="currentWindowIndex != 0" icon="fa-solid fa-chevron-left" size="small"></v-btn>
-                                        </div>
-                                        <div class="flex-col flex-grow-1 mt-auto mb-auto">
-                                            {{ mealPlanGridItem.date_label }}
-                                        </div>
-                                        <div class="flex-col align-self-end">
-                                            <v-btn @click="currentWindowIndex++" v-if="currentWindowIndex + 1 < mealPlanWindows.length" icon="fa-solid fa-chevron-right"
-                                                   size="small"></v-btn>
-                                        </div>
-                                    </div>
-                                </v-list-item>
-                                <v-progress-linear v-if="loading" height="1" indeterminate></v-progress-linear>
-                                <v-divider v-if="mealPlanGridItem.plan_entries.length > 0"></v-divider>
-                                <v-list-item v-for="p in mealPlanGridItem.plan_entries" :key="p.id" @click="clickMealPlan(p)" link>
-                                    <template #prepend>
-                                        <v-avatar :image="p.recipe.image" v-if="p.recipe?.image"></v-avatar>
-                                        <v-avatar image="../../assets/recipe_no_image.svg" v-else></v-avatar>
-                                    </template>
-                                    <v-list-item-title>
-                                        <span v-if="p.recipe">{{ p.recipe.name }}</span>
-                                        <span v-else>{{ p.title }}</span>
-                                    </v-list-item-title>
-                                    <v-list-item-subtitle>
-                                        {{ p.mealType.name }}
-                                    </v-list-item-subtitle>
-                                    <model-edit-dialog model="MealPlan" :item="p" v-if="!p.recipe"></model-edit-dialog>
-                                    <template #append>
-                                        <v-btn icon variant="plain">
-                                            <v-icon icon="$menu"></v-icon>
-                                            <v-menu activator="parent">
-                                                <v-list>
-                                                    <v-list-item prepend-icon="$edit" link>
-                                                        {{ $t('Edit') }}
-                                                        <model-edit-dialog model="MealPlan" :item="p"></model-edit-dialog>
-                                                    </v-list-item>
-                                                </v-list>
-                                            </v-menu>
-                                        </v-btn>
-                                    </template>
-                                </v-list-item>
-                                <v-list-item class="text-center cursor-pointer" variant="tonal">
-                                    <model-edit-dialog model="MealPlan" :item-defaults="{fromDate: mealPlanGridItem.date.toJSDate()}" :close-after-create="false"
-                                                       :close-after-save="false"></model-edit-dialog>
-                                    <v-icon icon="$create" size="small"></v-icon>
-                                </v-list-item>
-                            </v-list>
-                        </v-col>
-                    </v-row>
-                </v-window-item>
-            </v-window>
-        </v-col>
-    </v-row>
-
+  <v-row class="mt-0" v-if="mealPlanWindows.length > 0">
+    <v-col>
+      <v-window v-model="currentWindowIndex">
+        <v-window-item v-for="(w, i) in mealPlanWindows" :value="i" class="pt-1 pb-1">
+          <v-row>
+            <v-col v-for="mealPlanGridItem in w">
+              <v-list density="compact" class="pt-0 pb-0">
+                <v-list-item class="text-center">
+                  <div class="d-flex">
+                    <div class="flex-col align-self-start">
+                      <v-btn @click="currentWindowIndex--" v-if="currentWindowIndex != 0" icon="fa-solid fa-chevron-left" size="small"></v-btn>
+                    </div>
+                    <div class="flex-col flex-grow-1 mt-auto mb-auto">
+                      {{ mealPlanGridItem.date_label }}
+                    </div>
+                    <div class="flex-col align-self-end">
+                      <v-btn @click="currentWindowIndex++" v-if="currentWindowIndex + 1 < mealPlanWindows.length" icon="fa-solid fa-chevron-right" size="small"></v-btn>
+                    </div>
+                  </div>
+                </v-list-item>
+                <v-progress-linear v-if="loading" height="1" indeterminate></v-progress-linear>
+                <v-divider v-if="mealPlanGridItem.plan_entries.length > 0"></v-divider>
+                <v-list-item v-for="p in mealPlanGridItem.plan_entries" :key="p.id" @click="clickMealPlan(p)" link>
+                  <template #prepend>
+                    <v-avatar :image="p.recipe.image" v-if="p.recipe?.image"></v-avatar>
+                    <v-avatar image="../../assets/recipe_no_image.svg" v-else></v-avatar>
+                  </template>
+                  <v-list-item-title>
+                    <span v-if="p.recipe">{{ p.recipe.name }}</span>
+                    <span v-else>{{ p.title }}</span>
+                  </v-list-item-title>
+                  <v-list-item-subtitle>
+                    {{ p.mealType.name }}
+                  </v-list-item-subtitle>
+                  <model-edit-dialog model="MealPlan" :item="p" v-if="!p.recipe"></model-edit-dialog>
+                  <template #append>
+                    <v-btn icon variant="plain">
+                      <v-icon icon="$menu"></v-icon>
+                      <v-menu activator="parent">
+                        <v-list>
+                          <v-list-item prepend-icon="$edit" link>
+                            {{ $t("Edit") }}
+                            <model-edit-dialog model="MealPlan" :item="p"></model-edit-dialog>
+                          </v-list-item>
+                        </v-list>
+                      </v-menu>
+                    </v-btn>
+                  </template>
+                </v-list-item>
+                <v-list-item class="text-center cursor-pointer" variant="tonal">
+                  <model-edit-dialog
+                    model="MealPlan"
+                    :item-defaults="{ fromDate: mealPlanGridItem.date.toJSDate() }"
+                    :close-after-create="false"
+                    :close-after-save="false"
+                  ></model-edit-dialog>
+                  <v-icon icon="$create" size="small"></v-icon>
+                </v-list-item>
+              </v-list>
+            </v-col>
+          </v-row>
+        </v-window-item>
+      </v-window>
+    </v-col>
+  </v-row>
 </template>
 
-
 <script lang="ts" setup>
-import {computed, onMounted, ref} from 'vue'
-import {useDisplay} from "vuetify";
-import {MealPlan} from "@/openapi";
-import {useMealPlanStore} from "@/stores/MealPlanStore";
-import {DateTime} from "luxon";
-import {homePageCols} from "@/utils/breakpoint_utils";
-import ModelEditDialog from "@/components/dialogs/ModelEditDialog.vue";
-import {useRouter} from "vue-router";
+import { computed, onMounted, ref } from "vue"
+import { useDisplay } from "vuetify"
+import { MealPlan } from "@/openapi"
+import { useMealPlanStore } from "@/stores/MealPlanStore"
+import { DateTime } from "luxon"
+import { homePageCols } from "@/utils/breakpoint_utils"
+import ModelEditDialog from "@/components/dialogs/ModelEditDialog.vue"
+import { useRouter } from "vue-router"
 
 const router = useRouter()
-const {name} = useDisplay()
+const { name } = useDisplay()
 
 const loading = ref(false)
 const currentWindowIndex = ref(0)
 
 let numberOfCols = computed(() => {
-    return homePageCols(name.value)
+  return homePageCols(name.value)
 })
 
 type MealPlanGridItem = {
-    date: DateTime,
-    create_default_date: String,
-    date_label: String,
-    plan_entries: Array<MealPlan>,
+  date: DateTime
+  create_default_date: String
+  date_label: String
+  plan_entries: Array<MealPlan>
 }
 
 const meal_plan_grid = computed(() => {
-    let grid = [] as MealPlanGridItem[]
+  let grid = [] as MealPlanGridItem[]
 
-    for (const x of Array(4).keys()) {
-        let grid_day_date = DateTime.now().plus({days: x})
-        grid.push({
-            date: grid_day_date,
-            create_default_date: grid_day_date.toISODate(), // improve meal plan edit modal to do formatting itself and accept dates
-            date_label: grid_day_date.toLocaleString({
-                weekday: 'short',
-                month: '2-digit',
-                day: '2-digit',
-                year: '2-digit',
-            }),
-            plan_entries: useMealPlanStore().planList.filter((m: MealPlan) => ((DateTime.fromJSDate(m.fromDate).startOf('day') <= grid_day_date.startOf('day')) && (DateTime.fromJSDate((m.toDate != undefined) ? m.toDate : m.fromDate).startOf('day') >= grid_day_date.startOf('day')))),
-        } as MealPlanGridItem)
-    }
+  for (const x of Array(4).keys()) {
+    let grid_day_date = DateTime.now().plus({ days: x })
+    grid.push({
+      date: grid_day_date,
+      create_default_date: grid_day_date.toISODate(), // improve meal plan edit modal to do formatting itself and accept dates
+      date_label: grid_day_date.toLocaleString({
+        weekday: "short",
+        month: "2-digit",
+        day: "2-digit",
+        year: "2-digit",
+      }),
+      plan_entries: useMealPlanStore()
+        .planList.filter(
+          (m: MealPlan) =>
+            DateTime.fromJSDate(m.fromDate).startOf("day") <= grid_day_date.startOf("day") &&
+            DateTime.fromJSDate(m.toDate != undefined ? m.toDate : m.fromDate).startOf("day") >= grid_day_date.startOf("day")
+        )
+        .sort((a: MealPlan, b: MealPlan) => {
+          const timeA = a.mealType?.time ?? "￿"
+          const timeB = b.mealType?.time ?? "￿"
+          if (timeA !== timeB) return timeA < timeB ? -1 : 1
+          return (a.mealType?.order ?? 0) - (b.mealType?.order ?? 0)
+        }),
+    } as MealPlanGridItem)
+  }
 
-    return grid
+  return grid
 })
 
 let mealPlanWindows = computed(() => {
-    let windows = [] as Array<Array<MealPlanGridItem>>
-    let current_window = [] as Array<MealPlanGridItem>
-    for (const [i, mealPlanGridItem] of meal_plan_grid.value.entries()) {
-        current_window.push(mealPlanGridItem)
+  let windows = [] as Array<Array<MealPlanGridItem>>
+  let current_window = [] as Array<MealPlanGridItem>
+  for (const [i, mealPlanGridItem] of meal_plan_grid.value.entries()) {
+    current_window.push(mealPlanGridItem)
 
-        if (i % numberOfCols.value == numberOfCols.value - 1) {
-            if (current_window.length > 0) {
-                windows.push(current_window)
-            }
-            current_window = []
-        }
-    }
-    if (current_window.length > 0) {
+    if (i % numberOfCols.value == numberOfCols.value - 1) {
+      if (current_window.length > 0) {
         windows.push(current_window)
+      }
+      current_window = []
     }
-    return windows
+  }
+  if (current_window.length > 0) {
+    windows.push(current_window)
+  }
+  return windows
 })
 
 onMounted(() => {
-    loading.value = true
-    useMealPlanStore().refreshFromAPI(DateTime.now().toJSDate(), DateTime.now().plus({days: 7}).toJSDate()).finally(() => {
-        loading.value = false
+  loading.value = true
+  useMealPlanStore()
+    .refreshFromAPI(DateTime.now().toJSDate(), DateTime.now().plus({ days: 7 }).toJSDate())
+    .finally(() => {
+      loading.value = false
     })
 })
 
 function clickMealPlan(plan: MealPlan) {
-    if (plan.recipe) {
-        router.push({
-            name: 'RecipeViewPage',
-            params: {id: String(plan.recipe.id)},          // keep id in params
-            query: {servings: String(plan.servings ?? '')} // pass servings as query
-        })
-    }
+  if (plan.recipe) {
+    router.push({
+      name: "RecipeViewPage",
+      params: { id: String(plan.recipe.id) }, // keep id in params
+      query: { servings: String(plan.servings ?? "") }, // pass servings as query
+    })
+  }
 }
-
 </script>
 
-
-<style scoped>
-
-</style>
+<style scoped></style>


### PR DESCRIPTION
## What does this PR do?

The meal planner widget on the home page was displaying meals in creation order (the insertion order of the internal store map), rather than by the meal type starting time configured in _Settings → Meal Plan._

The calendar view already shows meals in the correct order because `vue-simple-calendar` sorts calendar items by `startDate`, and the backend serializer (`_apply_default_time`) bakes `mealType.time` into `fromDate` at save time. The home page widget had no equivalent sorting.

## Changes

**`vue3/src/components/display/HorizontalMealPlanWindow.vue`**

Added a `.sort()` after the `.filter()` in the `meal_plan_grid` computed property. Entries are sorted by:

1. `mealType.time` (primary) — the starting time set in meal plan settings, stored as `"HH:MM:SS"` and sortable lexicographically
2. `mealType.order` (secondary) — tiebreaker for meal types sharing the same time or without a time configured

Meal types with no time configured sort last.

## How to test

1. Create two or more meal types with different starting times in _Settings → Meal Plan_ (e.g. Breakfast at 08:00, Lunch at 12:00, Dinner at 18:00).
2. Add meal plan entries for today in non-chronological order (e.g. add Dinner first, then Breakfast).
3. Open the home page — the meal planner widget should now show entries in meal type time order (Breakfast → Lunch → Dinner), matching the calendar view.
