### PR TITLE
feat: add to existing pantry entries

### DIFF
--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -11,6 +11,7 @@ from django.forms.models import model_to_dict
 from django.contrib.auth.models import AnonymousUser, Group, User
 from django.core.cache import caches
 from django.core.mail import send_mail
+from django.db import IntegrityError, transaction
 from django.db.models import Q, QuerySet, Sum
 from django.http import BadHeaderError
 from django.urls import reverse
@@ -441,7 +442,7 @@ class SpaceSerializer(WritableNestedModelSerializer):
     def create(self, validated_data):
         if Space.objects.filter(created_by=self.context['request'].user).count() >= self.context['request'].user.userpreference.max_owned_spaces:
             raise serializers.ValidationError(
-                _('You have the reached the maximum amount of spaces that can be owned by you.') + f' ({self.context['request'].user.userpreference.max_owned_spaces})')
+                _('You have the reached the maximum amount of spaces that can be owned by you.') + f" ({self.context['request'].user.userpreference.max_owned_spaces})")
 
         name = None
         if 'name' in validated_data:
@@ -1750,7 +1751,20 @@ class InventoryEntrySerializer(SpacedModelSerializer, WritableNestedModelSeriali
         validated_data['created_by'] = self.context['request'].user
         validated_data['space'] = self.context['request'].space
 
-        instance = super().create(validated_data)
+        if validated_data.get('code'):
+            with transaction.atomic():
+                instance = InventoryEntry.objects.select_for_update().filter(space=validated_data['space'], code=validated_data['code']).first()
+                if instance:
+                    return self.add_to_existing_entry(instance, validated_data)
+
+        try:
+            instance = super().create(validated_data)
+        except IntegrityError:
+            if not validated_data.get('code'):
+                raise
+            with transaction.atomic():
+                instance = InventoryEntry.objects.select_for_update().get(space=validated_data['space'], code=validated_data['code'])
+                return self.add_to_existing_entry(instance, validated_data)
 
         if not instance.code:
             instance.code = hex(instance.id)[2:].upper()
@@ -1761,6 +1775,35 @@ class InventoryEntrySerializer(SpacedModelSerializer, WritableNestedModelSeriali
             entry=instance,
             booking_type=InventoryLog.B_ADD,
             old_amount=0,
+            new_amount=instance.amount,
+            old_inventory_location=instance.inventory_location,
+            new_inventory_location=instance.inventory_location,
+        )
+
+        return instance
+
+    def add_to_existing_entry(self, instance, validated_data):
+        unit = validated_data.get('unit')
+        if unit:
+            submitted_unit_names = (
+                {unit.get('name'), unit.get('plural_name')}
+                if isinstance(unit, dict) else {unit.name, unit.plural_name}
+            )
+            existing_unit_names = {instance.unit.name, instance.unit.plural_name} if instance.unit else set()
+            if not submitted_unit_names & existing_unit_names:
+                raise serializers.ValidationError({
+                    'unit': [_('Unit must match existing inventory entry unit for duplicate code.')]
+                })
+
+        old_amount = instance.amount
+        instance.amount += validated_data.get('amount') or Decimal(0)
+        instance.save()
+
+        InventoryLog.objects.create(
+            space=instance.space,
+            entry=instance,
+            booking_type=InventoryLog.B_ADD,
+            old_amount=old_amount,
             new_amount=instance.amount,
             old_inventory_location=instance.inventory_location,
             new_inventory_location=instance.inventory_location,
@@ -1795,6 +1838,7 @@ class InventoryEntrySerializer(SpacedModelSerializer, WritableNestedModelSeriali
             'food', 'unit', 'amount', 'expires', 'note', 'label', 'created_at', 'created_by'
         )
         read_only_fields = ('id', 'created_at', 'created_by')
+        validators = []
 
 
 class InventoryLogSerializer(SpacedModelSerializer):

--- a/cookbook/tests/api/test_api_inventory_entry.py
+++ b/cookbook/tests/api/test_api_inventory_entry.py
@@ -1,0 +1,164 @@
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+from django.contrib import auth
+from django_scopes import scopes_disabled
+from rest_framework.exceptions import ValidationError
+
+from cookbook.models import InventoryEntry, InventoryLog
+from cookbook.serializer import InventoryEntrySerializer
+from cookbook.tests.factories import FoodFactory, InventoryEntryFactory, InventoryLocationFactory, UnitFactory
+
+
+def build_inventory_entry_serializer(user, space, data):
+    request = SimpleNamespace(user=user, space=space)
+    return InventoryEntrySerializer(data=data, context={'request': request})
+
+
+def test_create_duplicate_code_increments_existing_entry(u1_s1, space_1):
+    user = auth.get_user(u1_s1)
+    with scopes_disabled():
+        food = FoodFactory(space=space_1)
+        unit = UnitFactory(space=space_1)
+        inventory_location = InventoryLocationFactory(space=space_1, created_by=user)
+        existing = InventoryEntryFactory(
+            space=space_1,
+            created_by=user,
+            inventory_location=inventory_location,
+            food=food,
+            unit=unit,
+            code='ABC123',
+            amount=Decimal('2.5'),
+        )
+
+    serializer = build_inventory_entry_serializer(user, space_1, {
+        'inventory_location': inventory_location.id,
+        'food': food.id,
+        'unit': unit.id,
+        'code': 'ABC123',
+        'amount': '3.25',
+    })
+
+    with scopes_disabled():
+        assert serializer.is_valid(), serializer.errors
+        result = serializer.save()
+
+    assert result.id == existing.id
+
+    with scopes_disabled():
+        existing.refresh_from_db()
+        assert InventoryEntry.objects.filter(space=space_1, code='ABC123').count() == 1
+        assert existing.amount == Decimal('5.75')
+
+
+def test_create_duplicate_code_adds_inventory_log(u1_s1, space_1):
+    user = auth.get_user(u1_s1)
+    with scopes_disabled():
+        food = FoodFactory(space=space_1)
+        unit = UnitFactory(space=space_1)
+        inventory_location = InventoryLocationFactory(space=space_1, created_by=user)
+        existing = InventoryEntryFactory(
+            space=space_1,
+            created_by=user,
+            inventory_location=inventory_location,
+            food=food,
+            unit=unit,
+            code='ABC123',
+            amount=Decimal('2.5'),
+        )
+
+    serializer = build_inventory_entry_serializer(user, space_1, {
+        'inventory_location': inventory_location.id,
+        'food': food.id,
+        'unit': unit.id,
+        'code': 'ABC123',
+        'amount': '3.25',
+    })
+
+    with scopes_disabled():
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+    with scopes_disabled():
+        log = InventoryLog.objects.get(entry=existing)
+        assert log.booking_type == InventoryLog.B_ADD
+        assert log.old_amount == Decimal('2.5')
+        assert log.new_amount == Decimal('5.75')
+        assert log.old_inventory_location == inventory_location
+        assert log.new_inventory_location == inventory_location
+
+
+def test_create_duplicate_code_with_different_unit_raises_validation_error(u1_s1, space_1):
+    user = auth.get_user(u1_s1)
+    with scopes_disabled():
+        food = FoodFactory(space=space_1)
+        unit = UnitFactory(space=space_1)
+        different_unit = UnitFactory(space=space_1)
+        inventory_location = InventoryLocationFactory(space=space_1, created_by=user)
+        existing = InventoryEntryFactory(
+            space=space_1,
+            created_by=user,
+            inventory_location=inventory_location,
+            food=food,
+            unit=unit,
+            code='ABC123',
+            amount=Decimal('2.5'),
+        )
+
+    serializer = build_inventory_entry_serializer(user, space_1, {
+        'inventory_location': inventory_location.id,
+        'food': food.id,
+        'unit': different_unit.id,
+        'code': 'ABC123',
+        'amount': '3.25',
+    })
+
+    with scopes_disabled():
+        assert serializer.is_valid(), serializer.errors
+        with pytest.raises(ValidationError) as exc_info:
+            serializer.save()
+        assert 'unit' in exc_info.value.detail
+
+        existing.refresh_from_db()
+        assert existing.amount == Decimal('2.5')
+
+
+def test_create_duplicate_code_preserves_existing_entry_details(u1_s1, space_1):
+    user = auth.get_user(u1_s1)
+    with scopes_disabled():
+        food = FoodFactory(space=space_1)
+        new_food = FoodFactory(space=space_1)
+        unit = UnitFactory(space=space_1)
+        inventory_location = InventoryLocationFactory(space=space_1, created_by=user)
+        new_inventory_location = InventoryLocationFactory(space=space_1, created_by=user)
+        existing = InventoryEntryFactory(
+            space=space_1,
+            created_by=user,
+            inventory_location=inventory_location,
+            sub_location='Pantry shelf',
+            food=food,
+            unit=unit,
+            code='ABC123',
+            amount=Decimal('2.5'),
+        )
+
+    serializer = build_inventory_entry_serializer(user, space_1, {
+        'inventory_location': new_inventory_location.id,
+        'sub_location': 'Other shelf',
+        'food': new_food.id,
+        'unit': unit.id,
+        'code': 'ABC123',
+        'amount': '3.25',
+    })
+
+    with scopes_disabled():
+        assert serializer.is_valid(), serializer.errors
+        serializer.save()
+
+        existing.refresh_from_db()
+        assert existing.amount == Decimal('5.75')
+        assert existing.inventory_location == inventory_location
+        assert existing.sub_location == 'Pantry shelf'
+        assert existing.food == food
+        assert existing.unit == unit

--- a/vue3/src/components/display/InventoryEntryTable.vue
+++ b/vue3/src/components/display/InventoryEntryTable.vue
@@ -33,6 +33,7 @@
         <template #item.action="{item}">
             <v-btn-group divided border density="comfortable">
                 <v-btn icon="fa-solid fa-clock-rotate-left" @click="entryLogDialog = true; entryLogEntry = item"></v-btn>
+                <v-btn icon="$create" :to="{name: 'InventoryBookingPage', query: {inventoryEntryId: item.id, bookingMode: 'add'}}"></v-btn>
                 <v-btn icon="fa-solid fa-minus" :to="{name: 'InventoryBookingPage', query: {inventoryEntryId: item.id, bookingMode: 'remove'}}"></v-btn>
                 <v-btn icon="fa-solid fa-arrow-right" :to="{name: 'InventoryBookingPage', query: {inventoryEntryId: item.id, bookingMode: 'move'}}"></v-btn>
             </v-btn-group>

--- a/vue3/src/pages/InventoryBookingPage.vue
+++ b/vue3/src/pages/InventoryBookingPage.vue
@@ -264,7 +264,11 @@ onMounted(() => {
         api.apiInventoryEntryRetrieve({id: inventoryEntryId.value}).then(r => {
             inventoryEntry.value = r
             inventoryEntryId.value = undefined
-            inventoryEntrySelected()
+            if (bookingMode.value == 'add') {
+                prefillAddFormFromInventoryEntry(r)
+            } else {
+                inventoryEntrySelected()
+            }
         })
     }
 })
@@ -412,6 +416,16 @@ function inventoryEntrySelected() {
         amount.value = inventoryEntry.value.amount
         //expires.value = inventoryEntry.value.expires
     }
+}
+
+function prefillAddFormFromInventoryEntry(entry: InventoryEntry) {
+    food.value = entry.food
+    unit.value = entry.unit
+    inventoryLocation.value = entry.inventoryLocation
+    subLocation.value = entry.subLocation ?? ''
+    code.value = entry.code ?? ''
+    expires.value = entry.expires ?? undefined
+    amount.value = 1
 }
 
 /**


### PR DESCRIPTION
## Summary

- add a per-row pantry action to add more stock to an existing inventory entry
- prefill inventory booking add mode from the selected pantry entry, including code/barcode
- handle duplicate inventory codes on create by incrementing the existing entry amount instead of surfacing a database conflict
- reject duplicate-code additions when the submitted unit does not match the existing inventory entry unit
- add focused serializer tests for amount increments, inventory log creation, preserving the original entry details, and unit mismatch validation

## Verification

- `python -m pytest cookbook/tests/api/test_api_inventory_entry.py -q`
- `python -m py_compile cookbook/serializer.py cookbook/tests/api/test_api_inventory_entry.py`
- `git diff --check`
- `yarn build`

## Manual smoke notes

I also used a local Tandoor container to inspect the current pantry flow: setup, empty pantry, adding an item through the API, viewing the pantry row, opening remove mode for the row, and removing the item from stock.
