### PR TITLE
fix: pass pagination parameters to inventory entry API call

### DIFF
--- a/vue3/src/components/display/InventoryEntryTable.vue
+++ b/vue3/src/components/display/InventoryEntryTable.vue
@@ -105,6 +105,8 @@ function loadItems(options: VDataTableUpdateOptions) {
 
     page.value = options.page
     pageSize.value = options.itemsPerPage
+    parameters.page = options.page
+    parameters.pageSize = options.itemsPerPage > 0 ? options.itemsPerPage : undefined
 
     api.apiInventoryEntryList(parameters).then((r: any) => {
         items.value = r.results


### PR DESCRIPTION
 ## Bug
  The Pantry page would only ever show 50 items regardless of the items-per-page setting chosen by the user. Changing to 10, 25, 100, or
  "All" had no effect.
  ## Root Cause
  `InventoryEntryTable.vue` was not passing the `page` and `pageSize` parameters to the API call. The `loadItems` function tracked these
  values locally but never included them in the request, so the API always returned the default first page of 50 items.
  
  ## Fix
  Pass `page` and `pageSize` from the table options into the API request parameters. The `pageSize > 0` check handles the "All" option
  which sends `-1`.
  
  ## Testing
  Verified the API request now includes `page` and `page_size` query parameters in the network request.

<img width="289" height="245" alt="Screenshot 2026-06-06 at 1 29 17 PM" src="https://github.com/user-attachments/assets/d9bead80-5dbb-4a62-8c93-7b808f88bf7a" />
