### PR TITLE
  fix: handle null description in Mealie import

### DIFF
--- a/cookbook/integration/mealie1.py
+++ b/cookbook/integration/mealie1.py
@@ -111,7 +111,7 @@ class Mealie1(Integration):
                 recipe = Recipe.objects.create(
                     waiting_time=parse_time(r['perform_time']),
                     working_time=parse_time(r['prep_time']),
-                    description=r['description'][:512],
+                    description=(r['description'] or '')[:512],
                     name=clean_name,
                     source_url=r['org_url'],
                     servings=servings,


### PR DESCRIPTION
## Bug
  Importing from Mealie fails with `'NoneType' object is not subscriptable` when any recipe has a null description. The entire import crashes and 0 recipes are imported.

  ## Root Cause
  `mealie1.py` line 114 slices `r['description']` with `[:512]` without checking for `None` first. Mealie allows recipes to have no description, so this field can be null in the export.
  
  ## Fix
  Use `(r['description'] or '')[:512]` to convert `None` to an empty string before slicing. This is the same pattern already used elsewhere in the file.