### PR TITLE
  fix: strip markdown code fences from AI response before JSON parsing

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -2080,7 +2080,7 @@ class RecipeViewSet(LoggingMixin, viewsets.ModelViewSet, DeleteRelationMixing):
                 ai_response = completion(**ai_request)
 
                 response_text = ai_response.choices[0].message.content
-
+                response_text = re.sub(r"^```(?:json)?\s*\n?(.*?)\n?```\s*$", r"\1", response_text.strip(), flags=re.DOTALL)
                 return Response(json.loads(response_text), status=status.HTTP_200_OK)
             except LitellmTimeout:
                 response = {
@@ -2812,6 +2812,8 @@ class AiImportView(APIView):
                 }
                 return Response(RecipeFromSourceResponseSerializer(context={'request': request}).to_representation(response), status=status.HTTP_400_BAD_REQUEST)
             response_text = ai_response.choices[0].message.content
+            
+            response_text = re.sub(r"^```(?:json)?\s*\n?(.*?)\n?```\s*$", r"\1", response_text.strip(), flags=re.DOTALL)
 
             try:
                 data_json = json.loads(response_text)


### PR DESCRIPTION
## Bug
  When using Anthropic Claude as an AI provider, the `aiproperties` endpoint crashes with `JSONDecodeError: Expecting value: line 1 column
  1 (char 0)`. Claude wraps its JSON response in a markdown code fence (```json ... ```) which causes `json.loads()` to fail since the
  first character is a backtick, not `{`.

  ## Root Cause
  `response_format={"type": "json_object"}` is passed to LiteLLM but the Anthropic backend does not enforce JSON-only responses the way
  OpenAI does — Claude is free to return JSON wrapped in a markdown code fence.
  ## Fix
  Strip markdown code fences from the AI response before calling `json.loads()` using `re.sub`. If no code fence is present (e.g. OpenAI,
  Gemini) the string passes through unchanged.
  
  The fix is applied in two places:
  - AI property generation endpoint (`aiproperties`)
  - AI recipe import endpoint

Unable to test locally without an Anthropic API key, but the fix follows the exact pattern suggested in the issue report.