### PR TITLE
  fix: return SyncLog error entry instead of False when local path is not allowed

### DIFF
--- a/cookbook/provider/local.py
+++ b/cookbook/provider/local.py
@@ -14,8 +14,13 @@ class Local(Provider):
     @staticmethod
     def import_all(monitor):
         if not Local.is_path_allowed(monitor.path):
-            return False
-
+            log_entry = SyncLog(
+                status='ERROR',
+                msg='Path not allowed',
+                sync=monitor,
+            )
+            log_entry.save()
+            return log_entry
         files = [f for f in listdir(monitor.path) if isfile(join(monitor.path, f))]
 
         import_count = 0


### PR DESCRIPTION
  ## Bug
  When syncing a local storage folder with a path that is not in `LOCAL_STORAGE_PATHS`, the `import_all` method in `local.py` returns
  `False`. The `query_synced_folder` endpoint then passes this boolean to `SyncLogSerializer`, which crashes with `AttributeError: 'bool'
  object has no attribute 'status'`, resulting in a 500 error.

  ## Root Cause
  `Local.import_all()` returns `False` on a path validation failure instead of a `SyncLog` object. The serializer expects a `SyncLog`
  
  ## Fix
  Instead of returning `False`, create and save a `SyncLog` entry with `status='ERROR'` and return it. This is consistent with the success
  path already in the same method and gives the serializer a valid object to work with.
  
  ## Testing
  Unable to test locally, but the fix follows the exact same pattern as the success case already in `local.py`.
