### PR TITLE
Fix AI import failing for images with non-JPEG MIME types (MPO, PNG, WebP)

### DIFF
--- a/cookbook/views/api.py
+++ b/cookbook/views/api.py
@@ -2751,8 +2751,8 @@ class AiImportView(APIView):
                 try:
                     img = PIL.Image.open(uploaded_file)
                     buffer = io.BytesIO()
-                    img.save(buffer, format=img.format)
-                    base64type = 'image/' + img.format
+                    img.convert('RGB').save(buffer, format='JPEG')
+                    base64type = 'image/jpeg'
                     file_bytes = buffer.getvalue()
                 except PIL.UnidentifiedImageError:
                     uploaded_file.seek(0)


### PR DESCRIPTION
## Problem

The AI image import fails with certain image formats due to two issues in `AiImportView.post`:

1. **Uppercase MIME type**: PIL returns `img.format` in uppercase (e.g. `'JPEG'`, `'PNG'`), so `base64type` becomes `'image/JPEG'` — rejected by Anthropic and some other providers that require lowercase.

2. **Format-specific types**: Camera apps on phones (Samsung, iPhone) can produce formats like MPO (multi-picture object, used for 3D/depth photos) or HEIC. These result in either an unsupported MIME type being sent (e.g. `image/MPO`, see #4173) or a `PIL.UnidentifiedImageError` which falls back to `application/pdf`, which is then rejected as an invalid PDF.

## Fix

Convert all PIL-readable images to JPEG before base64-encoding, producing a consistent lowercase `image/jpeg` MIME type that is universally accepted by AI providers:

```python
# Before
img.save(buffer, format=img.format)
base64type = 'image/' + img.format  # e.g. "image/JPEG", "image/MPO"

# After
img.convert('RGB').save(buffer, format='JPEG')
base64type = 'image/jpeg'
```

The `convert('RGB')` call is needed to handle images with transparency (RGBA) or palette modes that can't be saved directly as JPEG.

## Testing

Tested with JPEG, PNG, and MPO-style images. Verified that Anthropic (Claude) and Gemini both accept `image/jpeg` without error.

Fixes #4173