### PR TITLE
fix: add favorite to sort_order ALLOWED_KEYS and _NULLS_LAST

### DIFF
--- a/cookbook/helper/recipe_search.py
+++ b/cookbook/helper/recipe_search.py
@@ -13,7 +13,7 @@ from cookbook.managers import DICTIONARY, TextSearchConfig
 from cookbook.models import CustomFilter, SearchPreference
 from recipes import settings
 
-_NULLS_LAST = frozenset({'lastcooked', 'lastviewed', 'rating'})
+_NULLS_LAST = frozenset({'lastcooked', 'lastviewed', 'rating', 'favorite', 'times_cooked'})
 
 
 def _sort_includes(orderby, *fields):
@@ -25,7 +25,7 @@ def _sort_includes(orderby, *fields):
 
 def _finalize_ordering(orderby):
     result = []
-    ALLOWED_KEYS = ['random', 'score', '-score', 'name', '-name', 'lastcooked', '-lastcooked', 'rating', '-rating', 'times_cooked', '-times_cooked', 'created_at', '-created_at',
+    ALLOWED_KEYS = ['random', 'score', '-score', 'name', '-name', 'lastcooked', '-lastcooked', 'rating', '-rating', 'times_cooked', '-times_cooked', 'favorite', '-favorite', 'created_at', '-created_at',
                     'lastviewed', '-lastviewed', 'recent','-recent', 'new_recipe', '-new_recipe', '?']
     for key in orderby:
         # expressions cant come from user input so add them


### PR DESCRIPTION
## Summary

- Add `favorite` and `-favorite` to ALLOWED_KEYS so `sort_order=favorite` works
- Add `favorite` and `times_cooked` to `_NULLS_LAST` for proper NULL handling

## Problem

GET /api/recipe/?sort_order=favorite and GET /api/recipe/?sort_order=times_cooked return 500 errors since commit 322696f61.

- `favorite` was removed from ALLOWED_KEYS
- `times_cooked` is in ALLOWED_KEYS but not in `_NULLS_LAST`, so it doesn't get proper F() expression wrapping

## Fix

Added `favorite` and `-favorite` to ALLOWED_KEYS, and added both `favorite` and `times_cooked` to `_NULLS_LAST` so they get proper `nulls_last=True` handling.

Fixes #4720