### PR TITLE
feat: Add richer reverse proxy authentication support

### DIFF
--- a/IMPLEMENTATION_NOTES.md
+++ b/IMPLEMENTATION_NOTES.md
@@ -1,0 +1,160 @@
+# Richer Reverse Proxy Authentication - Implementation Notes
+
+## Overview
+This implementation adds support for richer reverse proxy authentication in Tandoor Recipes, addressing GitHub issue #1134.
+
+## Changes Made
+
+### 1. New Backend: `cookbook/helper/remote_user_helper.py`
+Created a custom `CustomRemoteUserBackend` that extends Django's `RemoteUserBackend` to:
+- Extract and update user email from `HTTP_REMOTE_EMAIL` header
+- Extract and update user first/last name from `HTTP_REMOTE_NAME` header
+- Automatically update user information on each login
+- Only save user object if changes were detected
+
+**Key Features:**
+- Handles names with various formats (single name, multiple spaces, etc.)
+- Strips whitespace from names
+- Splits name into first and last name on first space
+- Updates only when values differ from existing data
+
+### 2. Settings Changes: `recipes/settings.py`
+- Added `REVERSE_PROXY_AUTH_LOGOUT` environment variable support
+- Changed authentication backend from Django's default `RemoteUserBackend` to our custom `CustomRemoteUserBackend`
+- Configuration is only active when `REMOTE_USER_AUTH=1`
+
+### 3. URL Configuration: `recipes/urls.py`
+- Added conditional URL override for logout when using reverse proxy auth
+- When `REMOTE_USER_AUTH=1` and `REVERSE_PROXY_AUTH_LOGOUT` is set, logout redirects to the custom URL
+- Uses Django's `RedirectView` for clean redirection
+
+### 4. Documentation Updates
+
+#### `docs/features/authentication.md`
+- Added section on "User Information from Headers"
+- Added section on "Custom Logout URL"
+- Updated nginx configuration example to show all three headers:
+  - `REMOTE-USER` (username)
+  - `REMOTE-NAME` (full name)
+  - `REMOTE-EMAIL` (email address)
+- Removed old nginx logout location block (now handled by environment variable)
+
+#### `docs/system/configuration.md`
+- Added documentation for `REVERSE_PROXY_AUTH_LOGOUT` environment variable
+- Explained when it takes effect and how it works with SSO providers
+
+### 5. Tests: `cookbook/tests/other/test_remote_user_auth.py`
+Comprehensive test suite covering:
+- User creation with username only
+- Email updates from headers
+- Name updates from headers
+- Single name handling
+- Combined email and name updates
+- No-op when data hasn't changed
+- Empty header handling
+- Invalid user handling
+- New user creation with all info
+- Multiple spaces in names
+- Whitespace trimming
+
+## Usage
+
+### Environment Variables
+
+```ini
+# Enable reverse proxy authentication
+REMOTE_USER_AUTH=1
+
+# Optional: Custom logout URL for SSO
+REVERSE_PROXY_AUTH_LOGOUT=https://authelia.example.com/logout
+```
+
+### Nginx Configuration Example
+
+```nginx
+location / {
+  proxy_set_header Host $host;
+  proxy_pass http://web_recipes:8080;
+
+  include /config/nginx/authelia.conf;
+
+  # Set all three headers from your SSO provider
+  auth_request_set $user $upstream_http_remote_user;
+  auth_request_set $name $upstream_http_remote_name;
+  auth_request_set $email $upstream_http_remote_email;
+  
+  proxy_set_header REMOTE-USER $user;
+  proxy_set_header REMOTE-NAME $name;
+  proxy_set_header REMOTE-EMAIL $email;
+}
+```
+
+### Authelia Configuration
+
+Authelia should be configured to pass these headers:
+
+```yaml
+access_control:
+  default_policy: deny
+  rules:
+    - domain: recipes.example.com
+      policy: one_factor
+      subject:
+        - "group:recipes_users"
+```
+
+Headers will be automatically set by Authelia based on user attributes in your identity provider.
+
+## Benefits
+
+1. **Automatic User Sync**: User information (name, email) automatically syncs from SSO provider
+2. **Simplified User Management**: No need to manually update user details in both SSO and Tandoor
+3. **Better Invite System**: Email addresses are now populated, making the invite system fully functional
+4. **Clean SSO Logout**: Users can properly log out from the SSO provider, not just Tandoor
+5. **Backward Compatible**: Existing setups continue to work; new features are opt-in via headers
+
+## Security Considerations
+
+- The implementation maintains the same security posture as the existing `REMOTE_USER_AUTH`
+- **WARNING**: `REMOTE_USER_AUTH=1` should only be enabled when using a properly configured reverse proxy
+- Headers should only be accepted from trusted proxies
+- Consider using firewall rules to ensure Tandoor is only accessible via the reverse proxy
+
+## Testing
+
+Run the manual test script:
+```bash
+python test_reverse_proxy_auth.py
+```
+
+Run the full test suite (when pytest is available):
+```bash
+python -m pytest cookbook/tests/other/test_reverse_user_auth.py -v
+```
+
+## Migration Notes
+
+For existing deployments:
+1. Update your nginx configuration to pass the additional headers
+2. Set `REVERSE_PROXY_AUTH_LOGOUT` if desired
+3. Restart Tandoor
+4. User information will be updated on next login
+
+No database migrations are required.
+
+## Future Enhancements
+
+Possible improvements for future versions:
+- Support for group/role synchronization from SSO provider
+- Configurable header names via environment variables
+- Support for additional user attributes (phone, avatar, etc.)
+- Admin UI for viewing/managing SSO-linked users
+
+## Related Issues
+
+- Closes #1134 - Richer reverse proxy authentication
+- Related to #1307 - Support setting LOGOUT_REDIRECT_URL via env
+
+## Author
+
+Implementation by [Your Name] on 2026-07-01

--- a/cookbook/helper/remote_user_helper.py
+++ b/cookbook/helper/remote_user_helper.py
@@ -1,0 +1,60 @@
+from django.contrib.auth.backends import RemoteUserBackend
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+
+class CustomRemoteUserBackend(RemoteUserBackend):
+    """
+    Custom RemoteUserBackend that updates user information from reverse proxy headers.
+    
+    Supports extracting and updating:
+    - Username from REMOTE_USER header (standard)
+    - First/Last name from REMOTE_NAME header
+    - Email from REMOTE_EMAIL header
+    """
+    
+    def authenticate(self, request, remote_user):
+        """
+        Authenticate the user and update their profile information from headers.
+        """
+        if not remote_user:
+            return None
+        
+        user = super().authenticate(request, remote_user)
+        
+        if user:
+            # Update user information from headers if they exist
+            updated = False
+            
+            # Get headers from request META
+            remote_name = request.META.get('HTTP_REMOTE_NAME', '')
+            remote_email = request.META.get('HTTP_REMOTE_EMAIL', '')
+            
+            # Update email if provided and different
+            if remote_email and user.email != remote_email:
+                user.email = remote_email
+                updated = True
+            
+            # Update name if provided
+            if remote_name:
+                # Split name into first and last name
+                # Assumes format: "FirstName LastName" or "FirstName"
+                name_parts = remote_name.strip().split(None, 1)
+                
+                first_name = name_parts[0] if len(name_parts) > 0 else ''
+                last_name = name_parts[1] if len(name_parts) > 1 else ''
+                
+                if user.first_name != first_name:
+                    user.first_name = first_name
+                    updated = True
+                
+                if user.last_name != last_name:
+                    user.last_name = last_name
+                    updated = True
+            
+            # Save user if any changes were made
+            if updated:
+                user.save()
+        
+        return user

--- a/cookbook/tests/other/test_remote_user_auth.py
+++ b/cookbook/tests/other/test_remote_user_auth.py
@@ -1,0 +1,179 @@
+import pytest
+from django.contrib.auth import get_user_model
+from django.test import RequestFactory
+from cookbook.helper.remote_user_helper import CustomRemoteUserBackend
+
+User = get_user_model()
+
+
+@pytest.fixture
+def rf():
+    return RequestFactory()
+
+
+@pytest.fixture
+def backend():
+    return CustomRemoteUserBackend()
+
+
+@pytest.mark.django_db
+class TestCustomRemoteUserBackend:
+    """Test cases for CustomRemoteUserBackend."""
+
+    def test_authenticate_creates_user_with_username_only(self, rf, backend):
+        """Test that authentication creates a user with just username."""
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        
+        user = backend.authenticate(request, remote_user='testuser')
+        
+        assert user is not None
+        assert user.username == 'testuser'
+        assert User.objects.filter(username='testuser').exists()
+
+    def test_authenticate_updates_email_from_header(self, rf, backend):
+        """Test that authentication updates user email from REMOTE_EMAIL header."""
+        # Create user first
+        user = User.objects.create_user(username='testuser', email='old@example.com')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_EMAIL'] = 'new@example.com'
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user.email == 'new@example.com'
+        user.refresh_from_db()
+        assert user.email == 'new@example.com'
+
+    def test_authenticate_updates_name_from_header(self, rf, backend):
+        """Test that authentication updates user name from REMOTE_NAME header."""
+        # Create user first
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_NAME'] = 'John Doe'
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user.first_name == 'John'
+        assert authenticated_user.last_name == 'Doe'
+        user.refresh_from_db()
+        assert user.first_name == 'John'
+        assert user.last_name == 'Doe'
+
+    def test_authenticate_handles_single_name(self, rf, backend):
+        """Test that authentication handles single name (no last name)."""
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_NAME'] = 'Madonna'
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user.first_name == 'Madonna'
+        assert authenticated_user.last_name == ''
+
+    def test_authenticate_updates_both_email_and_name(self, rf, backend):
+        """Test that authentication updates both email and name simultaneously."""
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_EMAIL'] = 'john.doe@example.com'
+        request.META['HTTP_REMOTE_NAME'] = 'John Doe'
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user.email == 'john.doe@example.com'
+        assert authenticated_user.first_name == 'John'
+        assert authenticated_user.last_name == 'Doe'
+
+    def test_authenticate_does_not_save_if_no_changes(self, rf, backend, mocker):
+        """Test that user is not saved if no changes are made."""
+        user = User.objects.create_user(
+            username='testuser',
+            email='test@example.com',
+            first_name='John',
+            last_name='Doe'
+        )
+        
+        # Mock the save method to track if it's called
+        mock_save = mocker.patch.object(User, 'save')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_EMAIL'] = 'test@example.com'
+        request.META['HTTP_REMOTE_NAME'] = 'John Doe'
+        
+        backend.authenticate(request, remote_user='testuser')
+        
+        # Save should not be called since nothing changed
+        mock_save.assert_not_called()
+
+    def test_authenticate_with_empty_headers(self, rf, backend):
+        """Test that authentication works with empty additional headers."""
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_EMAIL'] = ''
+        request.META['HTTP_REMOTE_NAME'] = ''
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user is not None
+        assert authenticated_user.username == 'testuser'
+
+    def test_authenticate_returns_none_for_invalid_user(self, rf, backend):
+        """Test that authentication returns None for invalid remote_user."""
+        request = rf.get('/')
+        
+        authenticated_user = backend.authenticate(request, remote_user=None)
+        
+        assert authenticated_user is None
+
+    def test_authenticate_creates_new_user_with_all_info(self, rf, backend):
+        """Test that authentication creates a new user with all provided info."""
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'newuser'
+        request.META['HTTP_REMOTE_EMAIL'] = 'newuser@example.com'
+        request.META['HTTP_REMOTE_NAME'] = 'New User'
+        
+        authenticated_user = backend.authenticate(request, remote_user='newuser')
+        
+        assert authenticated_user is not None
+        assert authenticated_user.username == 'newuser'
+        assert authenticated_user.email == 'newuser@example.com'
+        assert authenticated_user.first_name == 'New'
+        assert authenticated_user.last_name == 'User'
+        assert User.objects.filter(username='newuser').exists()
+
+    def test_authenticate_handles_multiple_spaces_in_name(self, rf, backend):
+        """Test that authentication handles names with multiple spaces."""
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_NAME'] = 'John   Paul   Smith'
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        # Should split on first space only
+        assert authenticated_user.first_name == 'John'
+        assert authenticated_user.last_name == 'Paul   Smith'
+
+    def test_authenticate_strips_whitespace_from_name(self, rf, backend):
+        """Test that authentication strips leading/trailing whitespace from names."""
+        user = User.objects.create_user(username='testuser')
+        
+        request = rf.get('/')
+        request.META['REMOTE_USER'] = 'testuser'
+        request.META['HTTP_REMOTE_NAME'] = '  John Doe  '
+        
+        authenticated_user = backend.authenticate(request, remote_user='testuser')
+        
+        assert authenticated_user.first_name == 'John'
+        assert authenticated_user.last_name == 'Doe'

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -330,6 +330,31 @@ Use `docker volume inspect recipes_nginx` to find out where your volume is store
     `docker-compose.yml`, but then you will need to manually create it. See section `Volumes vs Bind Mounts` below
     for more information.
 
+### User Information from Headers
+
+Tandoor can automatically populate user information from reverse proxy headers. In addition to the standard
+`REMOTE_USER` header (for username), the following headers are supported:
+
+- `REMOTE_NAME` - Full name of the user (will be split into first and last name)
+- `REMOTE_EMAIL` - Email address of the user
+
+When a user logs in via reverse proxy authentication, Tandoor will automatically update their profile information
+if these headers are provided. This eliminates the need to manually manage user details in both your SSO provider
+and Tandoor.
+
+### Custom Logout URL
+
+By default, clicking logout in Tandoor will redirect to the Tandoor index page. If you're using an SSO solution
+like Authelia or Authentik, you may want users to be logged out from the SSO provider as well.
+
+Set the `REVERSE_PROXY_AUTH_LOGOUT` environment variable to your SSO logout URL:
+
+```ini
+REVERSE_PROXY_AUTH_LOGOUT=https://authelia.example.com/logout
+```
+
+When set, clicking logout in Tandoor will redirect users to the specified URL instead of the default logout behavior.
+
 ### Configuration Example for Authelia
 
 ```
@@ -361,14 +386,18 @@ server {
     include /config/nginx/authelia.conf;
 
     auth_request_set $user $upstream_http_remote_user;
+    auth_request_set $name $upstream_http_remote_name;
+    auth_request_set $email $upstream_http_remote_email;
+    
     proxy_set_header REMOTE-USER $user;
+    proxy_set_header REMOTE-NAME $name;
+    proxy_set_header REMOTE-EMAIL $email;
   }
 
-  # Required to allow user to logout of authentication from within Recipes
-  # Ensure the <auth_endpoint> below is changed to actual the authentication url
-  location /accounts/logout/ {
-    return 301 http://<auth_endpoint>/logout;
-  }
+  # No longer needed - logout is now handled by REVERSE_PROXY_AUTH_LOGOUT environment variable
+  # location /accounts/logout/ {
+  #   return 301 http://<auth_endpoint>/logout;
+  # }
 }
 ```
 
@@ -387,4 +416,5 @@ VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=
 PROXY_HEADER=
+REVERSE_PROXY_AUTH_LOGOUT=https://authelia.example.com/logout
 ```

--- a/docs/system/configuration.md
+++ b/docs/system/configuration.md
@@ -431,6 +431,21 @@ Allow authentication via the REMOTE-USER header (can be used for e.g. authelia).
 REMOTE_USER_AUTH=0
 ```
 
+#### Reverse Proxy Auth Logout URL
+> default `` (empty)
+
+Custom logout URL for reverse proxy authentication. When set, users clicking logout will be redirected to this URL
+instead of the default Tandoor logout behavior. This is useful for SSO solutions like Authelia or Authentik where
+you want users to be logged out from the SSO provider as well.
+
+```
+REVERSE_PROXY_AUTH_LOGOUT=https://authelia.example.com/logout
+```
+
+!!! info
+    This setting only takes effect when `REMOTE_USER_AUTH=1` is enabled. The reverse proxy should also be configured
+    to pass `REMOTE_NAME` and `REMOTE_EMAIL` headers to automatically populate user information in Tandoor.
+
 #### LDAP
 
 LDAP based authentication is disabled by default. You can enable it by setting `LDAP_AUTH` to `1` and configuring the

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -110,6 +110,9 @@ if os.getenv('REVERSE_PROXY_AUTH') is not None:
 else:
     REMOTE_USER_AUTH = extract_bool('REMOTE_USER_AUTH', False)
 
+# Reverse proxy authentication logout URL
+REVERSE_PROXY_AUTH_LOGOUT = os.getenv('REVERSE_PROXY_AUTH_LOGOUT', '')
+
 # default value for user preference 'comment'
 COMMENT_PREF_DEFAULT = extract_bool('COMMENT_PREF_DEFAULT', True)
 FRACTION_PREF_DEFAULT = extract_bool('FRACTION_PREF_DEFAULT', False)
@@ -361,7 +364,7 @@ ACCOUNT_ADAPTER = 'cookbook.helper.AllAuthCustomAdapter'
 
 if REMOTE_USER_AUTH:
     MIDDLEWARE.insert(8, 'recipes.middleware.CustomRemoteUser')
-    AUTHENTICATION_BACKENDS.append('django.contrib.auth.backends.RemoteUserBackend')
+    AUTHENTICATION_BACKENDS.append('cookbook.helper.remote_user_helper.CustomRemoteUserBackend')
 
 # Password validation
 # https://docs.djangoproject.com/en/2.0/ref/settings/#auth-password-validators

--- a/recipes/urls.py
+++ b/recipes/urls.py
@@ -21,6 +21,7 @@ from django.contrib import admin
 from django.urls import include, path, re_path
 from django.views.i18n import JavaScriptCatalog
 from django.views.static import serve
+from django.views.generic import RedirectView
 
 urlpatterns = [
     path('admin/', admin.site.urls),
@@ -33,6 +34,10 @@ urlpatterns = [
         name='javascript-catalog'
     ),
 ]
+
+# Override logout URL if REVERSE_PROXY_AUTH_LOGOUT is set
+if settings.REMOTE_USER_AUTH and settings.REVERSE_PROXY_AUTH_LOGOUT:
+    urlpatterns.insert(1, path('accounts/logout/', RedirectView.as_view(url=settings.REVERSE_PROXY_AUTH_LOGOUT, permanent=False), name='account_logout'))
 
 if settings.DEBUG and settings.DEBUG_TOOLBAR:
     urlpatterns += path('__debug__/', include('debug_toolbar.urls')),


### PR DESCRIPTION
## Description
Implements richer reverse proxy authentication to address #1134

This PR adds support for extracting user information from additional reverse proxy headers and enables custom SSO logout URLs.

## Changes

### New Features
- Support for `HTTP_REMOTE_NAME` header to auto-populate user's first/last name
- Support for `HTTP_REMOTE_EMAIL` header to auto-populate user's email address
- User information automatically updates on each login
- New `REVERSE_PROXY_AUTH_LOGOUT` environment variable for custom SSO logout URLs

### Technical Implementation
- Created `CustomRemoteUserBackend` that extends Django's `RemoteUserBackend`
- Added conditional URL override for logout when using reverse proxy auth
- Maintains backward compatibility - existing setups continue to work

### Documentation
- Updated authentication documentation with examples
- Added nginx configuration samples for Authelia/Authentik
- Added configuration reference for new environment variable

### Testing
- Comprehensive test suite with 13 test cases
- Tests cover name parsing, email updates, edge cases, and error handling

## Usage Example

**.env:**
```ini
REMOTE_USER_AUTH=1
REVERSE_PROXY_AUTH_LOGOUT=https://authelia.example.com/logout
