### PR TITLE
feat: add per-100g column to recipe nutrition label

### DIFF
--- a/cookbook/helper/property_helper.py
+++ b/cookbook/helper/property_helper.py
@@ -1,7 +1,7 @@
 from django.core.cache import caches
 
 from cookbook.helper.cache_helper import CacheHelper
-from cookbook.helper.unit_conversion_helper import UnitConversionHelper
+from cookbook.helper.unit_conversion_helper import BASE_UNITS_WEIGHT, UnitConversionHelper
 from cookbook.models import PropertyType
 
 
@@ -23,6 +23,7 @@ class FoodPropertyHelper:
         """
         ingredients = []
         computed_properties = {}
+        self.total_weight_grams = 0
 
         for s in recipe.steps.all():
             ingredients += s.ingredients.all()
@@ -43,6 +44,12 @@ class FoodPropertyHelper:
         for i in ingredients:
             if i.food is not None:
                 conversions = uch.get_conversions(i)
+
+                for c in conversions:
+                    if c.unit and c.unit.base_unit in BASE_UNITS_WEIGHT:
+                        self.total_weight_grams += uch.convert_from_to(c.unit.base_unit, 'g', c.amount)
+                        break
+
                 for pt in property_types:
                     # if a property could be calculated with an actual value
                     found_property = False

--- a/cookbook/serializer.py
+++ b/cookbook/serializer.py
@@ -1198,6 +1198,7 @@ class RecipeSerializer(RecipeBaseSerializer):
     rating = CustomDecimalField(required=False, allow_null=True, read_only=True)
     last_cooked = serializers.DateTimeField(required=False, allow_null=True, read_only=True)
     food_properties = serializers.SerializerMethodField('get_food_properties')
+    food_weight = serializers.SerializerMethodField('get_food_weight')
     created_by = UserSerializer(read_only=True)
 
     @extend_schema_field(serializers.JSONField)
@@ -1212,14 +1213,24 @@ class RecipeSerializer(RecipeBaseSerializer):
         fph = FoodPropertyHelper(obj.space)  # initialize with object space since recipes might be viewed anonymously
         return fph.calculate_recipe_properties(obj)
 
+    @extend_schema_field(float)
+    def get_food_weight(self, obj):
+        view = self.context.get('view')
+        if view and getattr(view, 'action', None) == 'create':
+            return 0
+
+        fph = FoodPropertyHelper(obj.space)  # initialize with object space since recipes might be viewed anonymously
+        fph.calculate_recipe_properties(obj)
+        return fph.total_weight_grams
+
     class Meta:
         model = Recipe
         fields = (
             'id', 'name', 'description', 'image', 'keywords', 'steps', 'working_time', 'waiting_time', 'created_by', 'created_at', 'updated_at', 'source_url',
-            'internal', 'show_ingredient_overview', 'nutrition', 'properties', 'food_properties', 'servings', 'file_path', 'servings_text', 'diameter', 'diameter_text', 'rating',
+            'internal', 'show_ingredient_overview', 'nutrition', 'properties', 'food_properties', 'food_weight', 'servings', 'file_path', 'servings_text', 'diameter', 'diameter_text', 'rating',
             'last_cooked', 'private', 'shared'
         )
-        read_only_fields = ['image', 'created_by', 'created_at', 'food_properties']
+        read_only_fields = ['image', 'created_by', 'created_at', 'food_properties', 'food_weight']
 
     def validate(self, data):
         above_limit, msg = above_space_limit(self.context['request'].space)

--- a/cookbook/tests/api/test_api_recipe.py
+++ b/cookbook/tests/api/test_api_recipe.py
@@ -235,7 +235,7 @@ def test_food_properties_skipped_on_create(u1_s1, space_1):
     CREATE skips expensive food_properties computation (returns {}) to avoid
     N+1 query timeouts. GET returns full computed values.
     """
-    from cookbook.models import PropertyType, Property
+    from cookbook.models import Property, PropertyType
 
     with scopes_disabled():
         unit = Unit.objects.create(name='gram', base_unit='g', space=space_1)
@@ -253,9 +253,11 @@ def test_food_properties_skipped_on_create(u1_s1, space_1):
     assert r.status_code == 201
     response = json.loads(r.content)
     assert response['food_properties'] == {}
+    assert response['food_weight'] == 0
 
     # GET returns computed food_properties
     r = u1_s1.get(reverse(DETAIL_URL, args=[response['id']]))
     assert r.status_code == 200
     get_response = json.loads(r.content)
     assert len(get_response['food_properties']) > 0
+    assert get_response['food_weight'] > 0

--- a/cookbook/tests/other/test_food_property.py
+++ b/cookbook/tests/other/test_food_property.py
@@ -126,3 +126,77 @@ def test_food_property(space_1, space_2, u1_s1):
         property_values = FoodPropertyHelper(space_1).calculate_recipe_properties(recipe_2)
 
         assert property_fat.id not in property_values
+
+
+def test_recipe_weight(space_1, space_2, u1_s1):
+    with scopes_disabled():
+        unit_gram = Unit.objects.create(name='gram_w', base_unit='g', space=space_1)
+        unit_kg = Unit.objects.create(name='kg_w', base_unit='kg', space=space_1)
+        unit_pcs = Unit.objects.create(name='pcs_w', base_unit='', space=space_1)
+
+        food_flour = Food.objects.create(name='flour_w', space=space_1, properties_food_unit=unit_gram, properties_food_amount=100)
+        food_sugar = Food.objects.create(name='sugar_w', space=space_1, properties_food_unit=unit_gram, properties_food_amount=100)
+        food_egg = Food.objects.create(name='egg_w', space=space_1, properties_food_unit=unit_gram, properties_food_amount=100)
+
+        pt_calories = PropertyType.objects.create(name='calories_w', space=space_1, unit='kcal')
+
+        prop_flour_cal = Property.objects.create(property_amount=364, property_type=pt_calories, space=space_1)
+        prop_sugar_cal = Property.objects.create(property_amount=400, property_type=pt_calories, space=space_1)
+        prop_egg_cal = Property.objects.create(property_amount=155, property_type=pt_calories, space=space_1)
+        food_flour.properties.add(prop_flour_cal)
+        food_sugar.properties.add(prop_sugar_cal)
+        food_egg.properties.add(prop_egg_cal)
+
+        caches['default'].delete(CacheHelper(space_1).PROPERTY_TYPE_CACHE_KEY)
+
+        print('\n----------- TEST RECIPE WEIGHT - GRAM UNITS ---------------')
+        recipe = Recipe.objects.create(name='recipe_weight_1', waiting_time=0, working_time=0, space=space_1, created_by=auth.get_user(u1_s1), servings=1)
+        step = Step.objects.create(instruction='step', space=space_1)
+        step.ingredients.create(amount=500, unit=unit_gram, food=food_flour, space=space_1)
+        step.ingredients.create(amount=500, unit=unit_gram, food=food_sugar, space=space_1)
+        recipe.steps.add(step)
+
+        fph = FoodPropertyHelper(space_1)
+        result = fph.calculate_recipe_properties(recipe)
+
+        assert abs(fph.total_weight_grams - Decimal(1000)) < 0.0001
+        assert abs(result[pt_calories.id]['total_value'] - Decimal(3820)) < 0.0001
+
+        print('\n----------- TEST RECIPE WEIGHT - KG CONVERSION ---------------')
+        recipe2 = Recipe.objects.create(name='recipe_weight_2', waiting_time=0, working_time=0, space=space_1, created_by=auth.get_user(u1_s1), servings=1)
+        step2 = Step.objects.create(instruction='step', space=space_1)
+        step2.ingredients.create(amount=1, unit=unit_kg, food=food_flour, space=space_1)
+        step2.ingredients.create(amount=200, unit=unit_gram, food=food_sugar, space=space_1)
+        recipe2.steps.add(step2)
+
+        fph2 = FoodPropertyHelper(space_1)
+        fph2.calculate_recipe_properties(recipe2)
+
+        assert abs(fph2.total_weight_grams - Decimal(1200)) < 0.0001
+
+        print('\n----------- TEST RECIPE WEIGHT - NO PCS CONVERSION ---------------')
+        recipe3 = Recipe.objects.create(name='recipe_weight_3', waiting_time=0, working_time=0, space=space_1, created_by=auth.get_user(u1_s1), servings=1)
+        step3 = Step.objects.create(instruction='step', space=space_1)
+        step3.ingredients.create(amount=500, unit=unit_gram, food=food_flour, space=space_1)
+        step3.ingredients.create(amount=2, unit=unit_pcs, food=food_egg, space=space_1)
+        recipe3.steps.add(step3)
+
+        fph3 = FoodPropertyHelper(space_1)
+        fph3.calculate_recipe_properties(recipe3)
+
+        assert abs(fph3.total_weight_grams - Decimal(500)) < 0.0001
+
+        print('\n----------- TEST RECIPE WEIGHT - PCS CONVERSION ---------------')
+        UnitConversion.objects.create(
+            base_amount=100,
+            base_unit=unit_gram,
+            converted_amount=2,
+            converted_unit=unit_pcs,
+            space=space_1,
+            created_by=auth.get_user(u1_s1),
+        )
+
+        fph4 = FoodPropertyHelper(space_1)
+        fph4.calculate_recipe_properties(recipe3)
+
+        assert abs(fph4.total_weight_grams - Decimal(600)) < 0.0001

--- a/vue3/src/components/display/PropertyView.vue
+++ b/vue3/src/components/display/PropertyView.vue
@@ -14,7 +14,13 @@
                 <thead>
                 <tr>
                     <th></th>
-                    <th>{{ $t('per_serving') }}</th>
+                    <th>
+                        {{ $t('per_serving') }}
+                        <div class="text-caption text-medium-emphasis" v-if="showPer100g && servingWeightGrams > 0">
+                            {{ $n(roundDecimals(servingWeightGrams)) }} g
+                        </div>
+                    </th>
+                    <th v-if="showPer100g">{{ $t('per_100g') }}</th>
                     <th>{{ $t('total') }}</th>
                     <th v-if="sourceSelectedToShow == 'food'"></th>
                 </tr>
@@ -23,6 +29,7 @@
                 <tr v-for="p in propertyList" :key="p.id">
                     <td>{{ p.name }}</td>
                     <td>{{ $n(roundDecimals(p.propertyAmountPerServing)) }} {{ p.unit }}</td>
+                    <td v-if="showPer100g">{{ $n(roundDecimals(p.propertyAmountPer100g)) }} {{ p.unit }}</td>
                     <td>{{ $n(roundDecimals(p.propertyAmountTotal)) }} {{ p.unit }}</td>
                     <td v-if="sourceSelectedToShow == 'food'">
                         <v-btn @click="dialogProperty = p; dialog = true" variant="plain" color="warning" icon="fa-solid fa-triangle-exclamation" size="small" class="d-print-none"
@@ -95,6 +102,7 @@ type PropertyWrapper = {
     foodValues: [],
     propertyAmountPerServing: number,
     propertyAmountTotal: number,
+    propertyAmountPer100g: number,
     missingValue: boolean,
     unit?: string,
     type: PropertyType,
@@ -130,6 +138,10 @@ const hasFoodProperties = computed(() => {
     return propertiesFound
 })
 
+const totalWeightGrams = computed(() => recipe.value.foodWeight ?? 0)
+const servingWeightGrams = computed(() => totalWeightGrams.value > 0 && recipe.value.servings > 0 ? totalWeightGrams.value / recipe.value.servings : 0)
+const showPer100g = computed(() => sourceSelectedToShow.value == 'food' && totalWeightGrams.value > 0)
+
 /**
  * compute list of properties based on recipe or food, depending on what is selected
  */
@@ -147,6 +159,7 @@ const propertyList = computed(() => {
                         foodValues: [],
                         propertyAmountPerServing: rp.propertyAmount,
                         propertyAmountTotal: rp.propertyAmount * recipe.value.servings * props.ingredientFactor,
+                        propertyAmountPer100g: 0,
                         missingValue: false,
                         unit: rp.propertyType.unit,
                         type: rp.propertyType,
@@ -165,6 +178,7 @@ const propertyList = computed(() => {
                     foodValues: fp.food_values,
                     propertyAmountPerServing: fp.total_value / recipe.value.servings,
                     propertyAmountTotal: fp.total_value * props.ingredientFactor,
+                    propertyAmountPer100g: totalWeightGrams.value > 0 ? fp.total_value / totalWeightGrams.value * 100 : 0,
                     missingValue: fp.missing_value,
                     unit: fp.unit,
                     type: fp,

--- a/vue3/src/locales/en.json
+++ b/vue3/src/locales/en.json
@@ -899,6 +899,7 @@
   "paste_ingredients": "Paste Ingredients",
   "paste_ingredients_placeholder": "Paste ingredient list here...",
   "paste_json": "Paste json or html source here to load recipe.",
+  "per_100g": "per 100g",
   "per_serving": "per servings",
   "pint": "pint [pt] (US, volume)",
   "plural_short": "plural",

--- a/vue3/src/openapi/models/PatchedRecipe.ts
+++ b/vue3/src/openapi/models/PatchedRecipe.ts
@@ -162,6 +162,12 @@ export interface PatchedRecipe {
      * @type {number}
      * @memberof PatchedRecipe
      */
+    readonly foodWeight?: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof PatchedRecipe
+     */
     servings?: number;
     /**
      * 
@@ -247,6 +253,7 @@ export function PatchedRecipeFromJSONTyped(json: any, ignoreDiscriminator: boole
         'nutrition': json['nutrition'] == null ? undefined : NutritionInformationFromJSON(json['nutrition']),
         'properties': json['properties'] == null ? undefined : ((json['properties'] as Array<any>).map(PropertyFromJSON)),
         'foodProperties': json['food_properties'] == null ? undefined : json['food_properties'],
+        'foodWeight': json['food_weight'] == null ? undefined : json['food_weight'],
         'servings': json['servings'] == null ? undefined : json['servings'],
         'filePath': json['file_path'] == null ? undefined : json['file_path'],
         'servingsText': json['servings_text'] == null ? undefined : json['servings_text'],
@@ -263,7 +270,7 @@ export function PatchedRecipeToJSON(json: any): PatchedRecipe {
     return PatchedRecipeToJSONTyped(json, false);
 }
 
-export function PatchedRecipeToJSONTyped(value?: Omit<PatchedRecipe, 'image'|'created_by'|'created_at'|'updated_at'|'food_properties'|'rating'|'last_cooked'> | null, ignoreDiscriminator: boolean = false): any {
+export function PatchedRecipeToJSONTyped(value?: Omit<PatchedRecipe, 'image'|'created_by'|'created_at'|'updated_at'|'food_properties'|'food_weight'|'rating'|'last_cooked'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }

--- a/vue3/src/openapi/models/Recipe.ts
+++ b/vue3/src/openapi/models/Recipe.ts
@@ -162,6 +162,12 @@ export interface Recipe {
      * @type {number}
      * @memberof Recipe
      */
+    readonly foodWeight: number;
+    /**
+     * 
+     * @type {number}
+     * @memberof Recipe
+     */
     servings?: number;
     /**
      * 
@@ -224,6 +230,7 @@ export function instanceOfRecipe(value: object): value is Recipe {
     if (!('createdAt' in value) || value['createdAt'] === undefined) return false;
     if (!('updatedAt' in value) || value['updatedAt'] === undefined) return false;
     if (!('foodProperties' in value) || value['foodProperties'] === undefined) return false;
+    if (!('foodWeight' in value) || value['foodWeight'] === undefined) return false;
     if (!('rating' in value) || value['rating'] === undefined) return false;
     if (!('lastCooked' in value) || value['lastCooked'] === undefined) return false;
     return true;
@@ -256,6 +263,7 @@ export function RecipeFromJSONTyped(json: any, ignoreDiscriminator: boolean): Re
         'nutrition': json['nutrition'] == null ? undefined : NutritionInformationFromJSON(json['nutrition']),
         'properties': json['properties'] == null ? undefined : ((json['properties'] as Array<any>).map(PropertyFromJSON)),
         'foodProperties': json['food_properties'],
+        'foodWeight': json['food_weight'],
         'servings': json['servings'] == null ? undefined : json['servings'],
         'filePath': json['file_path'] == null ? undefined : json['file_path'],
         'servingsText': json['servings_text'] == null ? undefined : json['servings_text'],
@@ -272,7 +280,7 @@ export function RecipeToJSON(json: any): Recipe {
     return RecipeToJSONTyped(json, false);
 }
 
-export function RecipeToJSONTyped(value?: Omit<Recipe, 'image'|'created_by'|'created_at'|'updated_at'|'food_properties'|'rating'|'last_cooked'> | null, ignoreDiscriminator: boolean = false): any {
+export function RecipeToJSONTyped(value?: Omit<Recipe, 'image'|'created_by'|'created_at'|'updated_at'|'food_properties'|'food_weight'|'rating'|'last_cooked'> | null, ignoreDiscriminator: boolean = false): any {
     if (value == null) {
         return value;
     }


### PR DESCRIPTION
To be upfront, I have done most of this with GLM 5.2, but I tried my best to strip the final version of all reimplementations of existing helpers and such.

I have tested this on my live proxmox lxc install of tandoor and found no side effects, during adding or editing of new and or existing recipes. Furthermore I consumed the API with SparkyFitness and could not find any difference in its behaviour.

I have read and signed the CLA.

Add a "per 100g" column to the property view alongside the existing "per serving" and "total" columns.

- FoodPropertyHelper: compute total_weight_grams from ingredient weight conversions during calculate_recipe_properties()
- RecipeSerializer: add food_weight read-only field exposing the computed weight (skipped on create, like food_properties)
- PropertyView.vue: add per_100g column with serving weight subtitle
- API client (Recipe.ts, PatchedRecipe.ts): add foodWeight field



<img width="1030" height="413" alt="grafik" src="https://github.com/user-attachments/assets/b168f0da-7579-49f2-9189-bb6994affce2" />
