### PR TITLE
Fix broken Traefik example link

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -76,7 +76,7 @@ If you use Traefik, this configuration is the one for you.
 !!! info
     Traefik can be a little confusing to setup.
     Please refer to [their excellent documentation](https://doc.traefik.io/traefik/). If that does not help,
-    [this little example](traefik.md) might be for you.
+    the Docker Compose example below might help.
 
 ```shell
 wget https://raw.githubusercontent.com/vabene1111/recipes/develop/docs/install/docker/traefik-nginx/docker-compose.yml


### PR DESCRIPTION
## Summary

- remove the broken link to the missing `traefik.md` page
- direct readers to the Docker Compose example already included immediately below

Fixes #4000

## Validation

- verified `docs/install/docker/traefik-nginx/docker-compose.yml` exists
- verified no `traefik.md` link remains under `docs/`
- ran `git diff --check`
