### PR TITLE
Regional datetime formats fixes

### DIFF
--- a/vue3/src/apps/tandoor/Tandoor.vue
+++ b/vue3/src/apps/tandoor/Tandoor.vue
@@ -122,8 +122,7 @@
 <script lang="ts" setup>
 import GlobalSearchDialog from "@/components/inputs/GlobalSearchDialog.vue"
 
-import {useDisplay, useLocale} from "vuetify"
-import {toVuetifyLocale} from "@/vuetify"
+import {useDisplay} from "vuetify"
 import VSnackbarQueued from "@/components/display/VSnackbarQueued.vue";
 import {useUserPreferenceStore} from "@/stores/UserPreferenceStore";
 import NavigationDrawerContextMenu from "@/components/display/NavigationDrawerContextMenu.vue";
@@ -149,13 +148,6 @@ onMounted(() => {
             router.push({name: 'WelcomePage'})
         }
     })
-
-
-    const {current} = useLocale()
-    let locale = document.querySelector('html')!.getAttribute('lang')
-    if (locale != null) {
-        current.value = toVuetifyLocale(locale.toLowerCase())
-    }
 })
 
 /**

--- a/vue3/src/components/inputs/LanguageSelect.vue
+++ b/vue3/src/components/inputs/LanguageSelect.vue
@@ -64,7 +64,8 @@ interface LocalizationWithCoverage {
 
 const availableLocalizations = ref([] as LocalizationWithCoverage[])
 const {locale} = useI18n()
-const selectedLocale = ref((document.documentElement.lang || locale.value).replace(/_/g, '-').toLowerCase())
+const htmlLocale = document.documentElement.lang.replace(/_/g, '-').toLowerCase()
+const selectedLocale = ref(resolveLocale(htmlLocale) ? htmlLocale : locale.value)
 const helpDialog = ref(false)
 const helpDrawer = ref(true)
 

--- a/vue3/src/components/inputs/LanguageSelect.vue
+++ b/vue3/src/components/inputs/LanguageSelect.vue
@@ -1,7 +1,7 @@
 <template>
     <v-select
             :label="$t('Language')"
-            v-model="$i18n.locale"
+            v-model="selectedLocale"
             :items="availableLocalizations"
             item-title="display"
             item-value="code"
@@ -48,10 +48,10 @@
 <script setup lang="ts">
 
 import {onMounted, ref, computed} from "vue";
-import {ApiApi, Localization} from "@/openapi";
+import {ApiApi} from "@/openapi";
 import {ErrorMessageType, useMessageStore} from "@/stores/MessageStore.ts";
 import {useI18n} from "vue-i18n";
-import {SUPPORT_LOCALES, resolveLocale, localeCoverage, LOCALE_MIN_COVERAGE} from "@/i18n.ts";
+import {resolveLocale, localeCoverage} from "@/i18n.ts";
 import VClosableCardTitle from "@/components/dialogs/VClosableCardTitle.vue";
 import HelpView from "@/components/display/HelpView.vue";
 
@@ -64,6 +64,7 @@ interface LocalizationWithCoverage {
 
 const availableLocalizations = ref([] as LocalizationWithCoverage[])
 const {locale} = useI18n()
+const selectedLocale = ref((document.documentElement.lang || locale.value).replace(/_/g, '-').toLowerCase())
 const helpDialog = ref(false)
 const helpDrawer = ref(true)
 
@@ -105,7 +106,7 @@ onMounted(() => {
                     }
                 }
                 return {
-                    code: resolved,
+                    code: l.code!.replace(/_/g, '-').toLowerCase(),
                     language: l.language!,
                     display: l.language!,
                     coverage: fe
@@ -124,7 +125,7 @@ onMounted(() => {
 function updateLanguage() {
     const expires = new Date();
     expires.setTime(expires.getTime() + (100 * 365 * 24 * 60 * 60 * 1000));
-    document.cookie = `django_language=${locale.value}; expires=${expires.toUTCString()}; path=/`;
+    document.cookie = `django_language=${selectedLocale.value}; expires=${expires.toUTCString()}; path=/`;
     location.reload()
 }
 

--- a/vue3/src/i18n.ts
+++ b/vue3/src/i18n.ts
@@ -181,9 +181,9 @@ export function setLocale(i18n: I18n, locale: Locale, formattingLocale: string =
     i18n.global.locale = locale
     Settings.defaultLocale = formattingLocale
 
-    const vuetifyLocale = toVuetifyLocale(locale)
-    // Vuetify uses this key for messages, but needs the regional locale for dates.
-    vuetify.date.options.locale[vuetifyLocale] = formattingLocale
-    vuetify.locale.current.value = vuetifyLocale
+    const vuetifyMessageLocale = toVuetifyLocale(locale)
+    vuetify.locale.messages.value[formattingLocale] = vuetify.locale.messages.value[vuetifyMessageLocale]!
+    vuetify.locale.rtl.value[formattingLocale] = vuetify.locale.rtl.value[vuetifyMessageLocale] ?? false
+    vuetify.locale.current.value = formattingLocale
     vuetify.date.instance.locale = formattingLocale
 }

--- a/vue3/src/i18n.ts
+++ b/vue3/src/i18n.ts
@@ -8,6 +8,7 @@ import en from "@/locales/en.json";
 import {TANDOOR_PLUGINS} from "@/types/Plugins.ts";
 import {qualified as qualifiedLocales, coverage as localeCoverage, minCoverage as LOCALE_MIN_COVERAGE} from 'virtual:locale-coverage'
 import {Settings} from "luxon";
+import vuetify, {toVuetifyLocale} from "@/vuetify.ts";
 
 /**
  * lazy loading of translation, resources:
@@ -61,6 +62,34 @@ export function resolveLocale(code: string): string | null {
     return null
 }
 
+/**
+ * Preserve an explicitly selected region for formatting. For generic locales,
+ * prefer a browser locale for the same language (e.g. en + en-GB -> en-GB).
+ */
+export function resolveFormattingLocale(code: string, browserLocales: readonly string[] = []): string {
+    let requested: Intl.Locale
+    try {
+        requested = new Intl.Locale(code.replace(/_/g, '-'))
+    } catch {
+        return 'en-US'
+    }
+
+    if (requested.region) return requested.baseName
+
+    for (const browserCode of browserLocales) {
+        try {
+            const browserLocale = new Intl.Locale(browserCode)
+            const sameLanguage = browserLocale.language === requested.language
+            const sameScript = !requested.script || browserLocale.maximize().script === requested.maximize().script
+            if (sameLanguage && sameScript) return browserLocale.baseName
+        } catch {
+            // Ignore invalid browser locale entries and try the next one.
+        }
+    }
+
+    return requested.baseName
+}
+
 export function setupI18n() {
     const htmlLang = document.querySelector('html')!.getAttribute('lang')
     let locale = htmlLang ? resolveLocale(htmlLang) : null
@@ -70,6 +99,8 @@ export function setupI18n() {
         }
         locale = 'en'
     }
+    const browserLocales = navigator.languages?.length ? navigator.languages : [navigator.language]
+    const formattingLocale = resolveFormattingLocale(htmlLang || locale, browserLocales)
 
     // load i18n with locale en by default (Legacy mode — locale is a plain string, not a Ref)
     const i18n = createI18n({
@@ -88,7 +119,7 @@ export function setupI18n() {
     })
 
     // async load user locale into existing i18n instance
-    loadLocaleMessages(i18n, locale).catch(console.error)
+    loadLocaleMessages(i18n, locale, formattingLocale).catch(console.error)
 
     return i18n
 }
@@ -98,7 +129,7 @@ export function setupI18n() {
  * @param i18n instance of Vue i18n
  * @param locale string locale code to set (should be in SUPPORT_LOCALES)
  */
-export async function loadLocaleMessages(i18n: I18n, locale: Locale) {
+export async function loadLocaleMessages(i18n: I18n, locale: Locale, formattingLocale: string = locale) {
     // load locale messages, clone to avoid mutating the imported module object
     let messages = {...en}
     if (locale != 'en') {
@@ -138,7 +169,7 @@ export async function loadLocaleMessages(i18n: I18n, locale: Locale) {
     })
 
     // switch to given locale
-    setLocale(i18n, locale)
+    setLocale(i18n, locale, formattingLocale)
 }
 
 /**
@@ -146,8 +177,13 @@ export async function loadLocaleMessages(i18n: I18n, locale: Locale) {
  * @param i18n instance of Vue i18n
  * @param locale string locale code to set (should be in SUPPORT_LOCALES)
  */
-export function setLocale(i18n: I18n, locale: Locale): void {
+export function setLocale(i18n: I18n, locale: Locale, formattingLocale: string = locale): void {
     i18n.global.locale = locale
-    // set luxon locale
-    Settings.defaultLocale = locale
+    Settings.defaultLocale = formattingLocale
+
+    const vuetifyLocale = toVuetifyLocale(locale)
+    // Vuetify uses this key for messages, but needs the regional locale for dates.
+    vuetify.date.options.locale[vuetifyLocale] = formattingLocale
+    vuetify.locale.current.value = vuetifyLocale
+    vuetify.date.instance.locale = formattingLocale
 }

--- a/vue3/src/i18n.ts
+++ b/vue3/src/i18n.ts
@@ -80,8 +80,7 @@ export function resolveFormattingLocale(code: string, browserLocales: readonly s
         try {
             const browserLocale = new Intl.Locale(browserCode)
             const sameLanguage = browserLocale.language === requested.language
-            const sameScript = !requested.script || browserLocale.maximize().script === requested.maximize().script
-            if (sameLanguage && sameScript) return browserLocale.baseName
+            if (sameLanguage) return browserLocale.baseName
         } catch {
             // Ignore invalid browser locale entries and try the next one.
         }


### PR DESCRIPTION
Since some time (late 2025 - early 2026) Tandoor has started showing wrong datetime formats for regional variations of languages. It is just using plain language formats, e.g. "en" (which is the same as "en_us") for both "en_us" and "en_gb".

This PR targets this issue, trying to make it work correctly for regional variants.

Here is a comparison of datetime formats for different combinations of interface and browser languages, which I have tested myself:
<img width="1779" height="501" alt="image" src="https://github.com/user-attachments/assets/c1604fc7-c4c4-4b21-8edb-054cc1bf3275" />
It compares the formats of:
- some old commit of TandoorRecipes before changes in i18n
- current develop branch state
- JS format, which is produced by console.log(new Date('2011-12-13T14:15').toLocaleString('en_gb')); 
- branch which I currently propose to merge (**Disclaimer: it was made using AI, based on my branch**)
- my own efforts to tackle this problem in the https://github.com/kadavr95/recipes/tree/develop-manual branch. But theimplementation here was bad,as to fix the locale in date selectors I had just rolled back some changes made in TandoorRecipes during that i18n rework which led to current problems.

I guess this PR should close https://github.com/TandoorRecipes/recipes/issues/4360, as it seems to be about this exact problem.

**Disclaimer once again: the code changes were made with using AI**