### PR TITLE
Fix JPEG EXIF orientation during image processing

### DIFF
--- a/cookbook/helper/image_processing.py
+++ b/cookbook/helper/image_processing.py
@@ -1,12 +1,13 @@
 import os
 from io import BytesIO
 
-from PIL import Image
+from PIL import Image, ImageOps
 
 
 def rescale_image_jpeg(image_object, base_width=1020):
     img = Image.open(image_object)
-    icc_profile = img.info.get('icc_profile')  # remember color profile to not mess up colors
+    img = ImageOps.exif_transpose(img)
+    icc_profile = img.info.get('icc_profile')
     width_percent = (base_width / float(img.size[0]))
     height = int((float(img.size[1]) * float(width_percent)))
 


### PR DESCRIPTION
## Summary

This PR fixes JPEG images being displayed with incorrect orientation after upload by applying the EXIF orientation before resizing.

### Changes

- Import `ImageOps` from Pillow.
- Apply `ImageOps.exif_transpose()` immediately after opening JPEG images in `rescale_image_jpeg()`.

### Testing

- Reproduced the issue reported in #4765.
- Verified that the affected JPEG image is displayed with the correct orientation after upload.
- Verified that a smaller JPEG image also displays correctly.