### PR TITLE
Add configurable default space for authentication

### DIFF
--- a/cookbook/forms.py
+++ b/cookbook/forms.py
@@ -12,6 +12,7 @@ from django_scopes import scopes_disabled
 from django_scopes.forms import SafeModelChoiceField
 from hcaptcha.fields import hCaptchaField
 
+from .helper.social_auth import assign_social_default_access
 from .models import InviteLink, Recipe, Space, User, UserPreference, UserSpace
 
 
@@ -180,19 +181,7 @@ class AllAuthSocialSignupForm(SocialSignupForm):
 
     def signup(self, request, user):
         if settings.SOCIAL_DEFAULT_ACCESS:
-            with scopes_disabled():
-                space = Space.objects.first()
-                group = Group.objects.filter(name=settings.SOCIAL_DEFAULT_GROUP).first()
-                if space and group:
-                    user_space = UserSpace.objects.create(
-                        space=space, user=user, active=True
-                    )
-                    user_space.groups.add(group)
-                else:
-                    if not space:
-                        print(f'WARNING: SOCIAL_DEFAULT_ACCESS is enabled but no Space exists. Cannot auto-assign user {user}.')
-                    if not group:
-                        print(f'WARNING: SOCIAL_DEFAULT_GROUP={settings.SOCIAL_DEFAULT_GROUP!r} does not match any Group. Cannot auto-assign user {user}.')
+            assign_social_default_access(user, active=True)
 
 
 class CustomPasswordResetForm(ResetPasswordForm):

--- a/cookbook/helper/social_auth.py
+++ b/cookbook/helper/social_auth.py
@@ -1,0 +1,36 @@
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django_scopes import scopes_disabled
+
+from cookbook.models import Space, UserSpace
+
+
+def assign_social_default_access(user, active):
+    """Assign a user to the configured social-auth space and group."""
+    with scopes_disabled():
+        if settings.SOCIAL_DEFAULT_SPACE:
+            space = Space.objects.filter(pk=settings.SOCIAL_DEFAULT_SPACE).first()
+        else:
+            space = Space.objects.first()
+
+        group = Group.objects.filter(name=settings.SOCIAL_DEFAULT_GROUP).first()
+        if space and group:
+            user_space = UserSpace.objects.create(space=space, user=user, active=active)
+            user_space.groups.add(group)
+            return user_space
+
+        if not space:
+            if settings.SOCIAL_DEFAULT_SPACE:
+                print(
+                    f'WARNING: SOCIAL_DEFAULT_SPACE={settings.SOCIAL_DEFAULT_SPACE!r} does not match any Space. '
+                    f'Cannot auto-assign user {user}.'
+                )
+            else:
+                print(f'WARNING: SOCIAL_DEFAULT_ACCESS is enabled but no Space exists. Cannot auto-assign user {user}.')
+        if not group:
+            print(
+                f'WARNING: SOCIAL_DEFAULT_GROUP={settings.SOCIAL_DEFAULT_GROUP!r} does not match any Group. '
+                f'Cannot auto-assign user {user}.'
+            )
+
+        return None

--- a/cookbook/tests/other/test_social_auth.py
+++ b/cookbook/tests/other/test_social_auth.py
@@ -75,7 +75,7 @@ def invite_link(invite_space):
 
 # ---------------------- SOCIAL SIGNUP FORM TESTS -----------------------
 
-@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest')
+@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest', SOCIAL_DEFAULT_SPACE=0)
 def test_social_default_access_adds_user_to_existing_space(
     social_signup_space, new_social_user, signup_request
 ):
@@ -95,7 +95,7 @@ def test_social_default_access_adds_user_to_existing_space(
         assert us.groups.filter(name='guest').exists()
 
 
-@override_settings(SOCIAL_DEFAULT_ACCESS=False, SOCIAL_DEFAULT_GROUP='guest')
+@override_settings(SOCIAL_DEFAULT_ACCESS=False, SOCIAL_DEFAULT_GROUP='guest', SOCIAL_DEFAULT_SPACE=0)
 def test_social_default_access_disabled_does_nothing(
     social_signup_space, new_social_user, signup_request
 ):
@@ -108,7 +108,7 @@ def test_social_default_access_disabled_does_nothing(
         assert UserSpace.objects.filter(user=new_social_user).count() == 0
 
 
-@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest')
+@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest', SOCIAL_DEFAULT_SPACE=0)
 def test_social_default_access_uses_first_space(
     new_social_user, signup_request
 ):
@@ -128,6 +128,37 @@ def test_social_default_access_uses_first_space(
 
 
 @override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest')
+def test_social_default_access_uses_configured_space(
+    new_social_user, signup_request
+):
+    """SOCIAL_DEFAULT_SPACE should select a space other than the first one."""
+    with scopes_disabled():
+        Space.objects.create(name='First Space')
+        configured_space = Space.objects.create(name='Configured Space')
+
+    form = AllAuthSocialSignupForm.__new__(AllAuthSocialSignupForm)
+    with override_settings(SOCIAL_DEFAULT_SPACE=configured_space.pk):
+        form.signup(signup_request, new_social_user)
+
+    with scopes_disabled():
+        user_space = UserSpace.objects.get(user=new_social_user)
+        assert user_space.space == configured_space
+
+
+@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest', SOCIAL_DEFAULT_SPACE=999999)
+def test_social_default_access_missing_configured_space(
+    social_signup_space, new_social_user, signup_request, capsys
+):
+    """An invalid configured space should not silently grant access elsewhere."""
+    form = AllAuthSocialSignupForm.__new__(AllAuthSocialSignupForm)
+    form.signup(signup_request, new_social_user)
+
+    with scopes_disabled():
+        assert UserSpace.objects.filter(user=new_social_user).count() == 0
+    assert 'SOCIAL_DEFAULT_SPACE=999999 does not match any Space' in capsys.readouterr().out
+
+
+@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='guest', SOCIAL_DEFAULT_SPACE=0)
 def test_social_default_access_no_space_exists(
     new_social_user, signup_request
 ):
@@ -143,7 +174,7 @@ def test_social_default_access_no_space_exists(
         assert UserSpace.objects.filter(user=new_social_user).count() == 0
 
 
-@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='nonexistent_group')
+@override_settings(SOCIAL_DEFAULT_ACCESS=True, SOCIAL_DEFAULT_GROUP='nonexistent_group', SOCIAL_DEFAULT_SPACE=0)
 def test_social_default_access_bad_group(
     social_signup_space, new_social_user, signup_request
 ):

--- a/cookbook/views/views.py
+++ b/cookbook/views/views.py
@@ -29,6 +29,7 @@ from drf_spectacular.views import SpectacularRedocView, SpectacularSwaggerView
 from cookbook.forms import Recipe, SpaceCreateForm, SpaceJoinForm, User, UserCreateForm
 from cookbook.helper.HelperFunctions import str2bool
 from cookbook.helper.permission_helper import CustomIsGuest, GroupRequiredMixin, has_group_permission, share_link_valid, switch_user_active_space
+from cookbook.helper.social_auth import assign_social_default_access
 from cookbook.models import InviteLink, ShareLink, Space, UserSpace
 from cookbook.templatetags.theming_tags import get_theming_values
 from cookbook.version_info import VERSION_INFO
@@ -117,17 +118,8 @@ def space_overview(request):
                 return HttpResponseRedirect(reverse('view_invite', args=[join_form.cleaned_data['token']]))
     else:
         if settings.SOCIAL_DEFAULT_ACCESS and len(request.user.userspace_set.all()) == 0:
-            space = Space.objects.first()
-            group = Group.objects.filter(name=settings.SOCIAL_DEFAULT_GROUP).first()
-            if space and group:
-                user_space = UserSpace.objects.create(space=space, user=request.user, active=False)
-                user_space.groups.add(group)
+            if assign_social_default_access(request.user, active=False):
                 return HttpResponseRedirect(reverse('index'))
-            else:
-                if not space:
-                    print(f'WARNING: SOCIAL_DEFAULT_ACCESS is enabled but no Space exists. Cannot auto-assign user {request.user}.')
-                if not group:
-                    print(f'WARNING: SOCIAL_DEFAULT_GROUP={settings.SOCIAL_DEFAULT_GROUP!r} does not match any Group. Cannot auto-assign user {request.user}.')
         if 'signup_token' in request.session:
             return HttpResponseRedirect(reverse('view_invite', args=[request.session.pop('signup_token', '')]))
 

--- a/docs/features/authentication.md
+++ b/docs/features/authentication.md
@@ -78,7 +78,7 @@ set as environment variables.
     `SOCIALACCOUNT_PROVIDERS` credential configuration, not the provider module registration.
 
 Now the provider is configured and you should be able to sign up and sign in using the provider.
-Use the superuser account to grant permissions to the newly created users, or enable default access via `SOCIAL_DEFAULT_ACCESS` & `SOCIAL_DEFAULT_GROUP` (see [configuration docs](../system/configuration.md)).
+Use the superuser account to grant permissions to the newly created users, or enable default access via `SOCIAL_DEFAULT_ACCESS`, `SOCIAL_DEFAULT_GROUP`, and `SOCIAL_DEFAULT_SPACE` (see [configuration docs](../system/configuration.md)).
 
 ### Third-party authentication example
 
@@ -280,7 +280,7 @@ Administrators can view additional diagnostics on the **System** page (`/system/
 
 **User created but has no permissions**
 :   New social login users start with no space access by default. Use `SOCIAL_DEFAULT_ACCESS` and
-    `SOCIAL_DEFAULT_GROUP` environment variables to automatically grant permissions to new social login users.
+    `SOCIAL_DEFAULT_GROUP` and `SOCIAL_DEFAULT_SPACE` environment variables to automatically grant permissions to new social login users.
 
 ## LDAP
 

--- a/docs/system/configuration.md
+++ b/docs/system/configuration.md
@@ -348,7 +348,7 @@ access to the data.
 
 > default `0` (disabled) - options `0`, `1`
 
-When enabled, new social login users will automatically join the first existing space with the group configured in `SOCIAL_DEFAULT_GROUP`.
+When enabled, new social login users will automatically join the space configured in `SOCIAL_DEFAULT_SPACE` with the group configured in `SOCIAL_DEFAULT_GROUP`.
 
 ```
 SOCIAL_DEFAULT_ACCESS = 1
@@ -358,6 +358,14 @@ SOCIAL_DEFAULT_ACCESS = 1
 
 ```
 SOCIAL_DEFAULT_GROUP=guest
+```
+
+> default `0` (first existing space) - option: numeric space ID
+
+Set a specific space ID to avoid depending on creation order. If the configured space does not exist, users are not granted access to another space.
+
+```
+SOCIAL_DEFAULT_SPACE=1
 ```
 
 #### Enable Signup

--- a/recipes/settings.py
+++ b/recipes/settings.py
@@ -55,6 +55,7 @@ LOG_LEVEL = os.getenv("LOG_LEVEL", "WARNING")
 
 SOCIAL_DEFAULT_ACCESS = bool(int(os.getenv('SOCIAL_DEFAULT_ACCESS', False)))
 SOCIAL_DEFAULT_GROUP = os.getenv('SOCIAL_DEFAULT_GROUP', 'guest')
+SOCIAL_DEFAULT_SPACE = int(os.getenv('SOCIAL_DEFAULT_SPACE', 0))
 
 HIDE_LOGIN_FORM = bool(int(os.getenv('HIDE_LOGIN_FORM', False)))
 


### PR DESCRIPTION
## Summary

- add `SOCIAL_DEFAULT_SPACE` to select the space used by default-access authentication
- preserve the existing first-space behavior when the setting is `0`
- fail closed when a configured space ID does not exist
- share the assignment logic between social signup and the authenticated-user fallback
- document the new setting and add regression tests

## Testing

- `python -m compileall -q cookbook recipes`
- default, configured, and invalid-space helper behavior checks
- `git diff --check`

Closes #2262