### PR TITLE
fix: send active yes/no search filters

### DIFF
--- a/vue3/src/pages/SearchPage.vue
+++ b/vue3/src/pages/SearchPage.vue
@@ -353,7 +353,7 @@ function enableFiltersWithValues() {
 function isFilterDefaultValue(filter: any) {
     if (Array.isArray(filter.default) && Array.isArray(filter.modelValue)) {
         return filter.default.length == filter.modelValue.length
-    } else if (isNaN(filter.default) && isNaN(filter.modelValue)) {
+    } else if (Number.isNaN(filter.default) && Number.isNaN(filter.modelValue)) {
         return true
     } else {
         return toRaw(filter.default) === filter.modelValue


### PR DESCRIPTION
## Description

I changed the search filter default check to use `Number.isNaN`. Previously, the coercing global `isNaN` treated the `"false"` and `"true"` Yes/No values as defaults; now an active value is included in the recipe request.

Fixes #4788

## Verification

- before: `makenow` with default `"false"` and value `"true"` was classified as default
- after: the focused SearchPage predicate check classifies that value as active while preserving unset numeric, NaN, and list defaults
- `npm run build` from `vue3`
