### PR TITLE
Render recipe and step times as hours and minutes

### DIFF
--- a/vue3/src/components/display/RecipeCard.vue
+++ b/vue3/src/components/display/RecipeCard.vue
@@ -29,7 +29,7 @@
                     </v-chip>
                     <v-chip class="mb-1 me-1" size="x-small" prepend-icon="far fa-clock" label variant="outlined"
                             v-if="props.recipe.workingTime != undefined && props.recipe.workingTime > 0">
-                        {{ recipe.workingTime! + recipe.waitingTime! }}
+                        {{ displayDuration(recipe.workingTime! + recipe.waitingTime!) }}
                     </v-chip>
                 </template>
             </keywords-component>
@@ -105,6 +105,9 @@ import RecipeContextMenu from "@/components/inputs/RecipeContextMenu.vue";
 import RecipeImage from "@/components/display/RecipeImage.vue";
 import {useRouter} from "vue-router";
 import PrivateRecipeBadge from "@/components/display/PrivateRecipeBadge.vue";
+import {useDurationDisplay} from "@/composables/useDurationDisplay.ts";
+
+const displayDuration = useDurationDisplay()
 
 const props = defineProps({
     recipe: {type: {} as PropType<Recipe | RecipeOverview>, required: true,},

--- a/vue3/src/components/display/RecipeView.vue
+++ b/vue3/src/components/display/RecipeView.vue
@@ -40,11 +40,11 @@
                 <v-container>
                     <v-row class="text-center text-body-2">
                         <v-col class="pt-1 pb-1">
-                            <i class="fas fa-cogs fa-fw mr-1"></i> {{ recipe.workingTime }} min<br/>
+                            <i class="fas fa-cogs fa-fw mr-1"></i> {{ displayDuration(recipe.workingTime) }}<br/>
                             <div class="text-grey">{{ $t('WorkingTime') }}</div>
                         </v-col>
                         <v-col class="pt-1 pb-1">
-                            <div><i class="fas fa-hourglass-half fa-fw mr-1"></i> {{ recipe.waitingTime }} min</div>
+                            <div><i class="fas fa-hourglass-half fa-fw mr-1"></i> {{ displayDuration(recipe.waitingTime) }}</div>
                             <div class="text-grey">{{ $t('WaitingTime') }}</div>
                         </v-col>
                         <v-col class="pt-1 pb-1">
@@ -95,11 +95,11 @@
 
                         <v-row class="text-center text-body-2 mb-1 flex-grow-0">
                             <v-col>
-                                <i class="fas fa-cogs fa-fw mr-1"></i> {{ recipe.workingTime }} {{ $t('min') }}<br/>
+                                <i class="fas fa-cogs fa-fw mr-1"></i> {{ displayDuration(recipe.workingTime) }}<br/>
                                 <div class="text-grey">{{ $t('WorkingTime') }}</div>
                             </v-col>
                             <v-col>
-                                <div><i class="fas fa-hourglass-half fa-fw mr-1"></i> {{ recipe.waitingTime }} {{ $t('min') }}</div>
+                                <div><i class="fas fa-hourglass-half fa-fw mr-1"></i> {{ displayDuration(recipe.waitingTime) }}</div>
                                 <div class="text-grey">{{ $t('WaitingTime') }}</div>
                             </v-col>
                             <v-col>
@@ -216,6 +216,9 @@ import {useFileApi} from "@/composables/useFileApi.ts";
 import PrivateRecipeBadge from "@/components/display/PrivateRecipeBadge.vue";
 import ModelSelect from "@/components/inputs/ModelSelect.vue";
 import RecipeScalingDialog from "@/components/dialogs/RecipeScalingDialog.vue";
+import {useDurationDisplay} from "@/composables/useDurationDisplay.ts";
+
+const displayDuration = useDurationDisplay()
 import VModelSelect from "@/components/inputs/VModelSelect.vue";
 
 const {request, release} = useWakeLock()

--- a/vue3/src/components/display/StepView.vue
+++ b/vue3/src/components/display/StepView.vue
@@ -9,7 +9,7 @@
                 <v-col class="text-right">
                     <v-btn-group density="compact" variant="tonal" class="d-print-none">
                         <v-btn size="small" color="info" v-if="step.time != undefined && step.time > 0" @click="timerRunning = true"><i
-                            class="fas fa-stopwatch mr-1 fa-fw"></i> {{ step.time }}
+                            class="fas fa-stopwatch mr-1 fa-fw"></i> {{ displayDuration(step.time) }}
                         </v-btn>
                         <v-btn size="small" color="success" v-if="hasDetails" @click="stepChecked = !stepChecked"><i class="fas fa-fw"
                                                                                                                      :class="{'fa-check': !stepChecked, 'fa-times': stepChecked}"></i>
@@ -63,6 +63,9 @@ import {Step} from "@/openapi";
 import Instructions from "@/components/display/Instructions.vue";
 import Timer from "@/components/display/Timer.vue";
 import {useUserPreferenceStore} from "@/stores/UserPreferenceStore.ts";
+import {useDurationDisplay} from "@/composables/useDurationDisplay.ts";
+
+const displayDuration = useDurationDisplay()
 
 const step = defineModel<Step>({required: true})
 

--- a/vue3/src/composables/useDurationDisplay.ts
+++ b/vue3/src/composables/useDurationDisplay.ts
@@ -1,0 +1,16 @@
+import {useI18n} from 'vue-i18n'
+import {formatDuration} from '@/utils/duration_utils'
+
+export type DurationDisplay = (minutes: number | null | undefined) => string
+
+/**
+ * binds the shared duration formatter to the active locale, for use at the read only duration
+ * displays (recipe times, step times, step timer button)
+ *
+ * @returns a function rendering a duration given in minutes for display
+ */
+export function useDurationDisplay(): DurationDisplay {
+    const {t} = useI18n()
+
+    return (minutes: number | null | undefined) => formatDuration(minutes, {hour: t('h'), minute: t('min')})
+}

--- a/vue3/src/locales/en.json
+++ b/vue3/src/locales/en.json
@@ -849,6 +849,7 @@
   "food_recipe_help": "Linking a recipe here will include the linked recipe in any other recipe that use this food",
   "g": "gram [g] (metric, weight)",
   "gallon": "gallon [gal] (US, volume)",
+  "h": "h",
   "help_translate": "Help Translate",
   "hide_step_ingredients": "Hide Step Ingredients",
   "hours": "hours",

--- a/vue3/src/utils/duration_utils.ts
+++ b/vue3/src/utils/duration_utils.ts
@@ -1,0 +1,43 @@
+/**
+ * unit labels used when rendering a duration
+ * passed in by the caller so that no unit string is ever inlined in the conversion logic
+ */
+export interface DurationLabels {
+    hour: string
+    minute: string
+}
+
+/**
+ * English fallbacks, used when a caller has no i18n context (tests, plain scripts)
+ */
+export const DEFAULT_DURATION_LABELS: DurationLabels = {hour: 'h', minute: 'min'}
+
+/**
+ * formats a duration given in minutes for display
+ *
+ * below one hour the duration is rendered as plain minutes, from one hour upwards as hours plus the
+ * remaining minutes when there are any (90 -> "1 h 30 min", 120 -> "2 h"). Days are deliberately not
+ * used, a 72 hour proof reads as "72 h".
+ *
+ * @param minutes duration in minutes, as stored on recipes and steps
+ * @param labels translated unit labels
+ * @returns the formatted duration, empty for a missing value
+ */
+export function formatDuration(minutes: number | null | undefined, labels: DurationLabels = DEFAULT_DURATION_LABELS): string {
+    if (minutes === null || minutes === undefined || Number.isNaN(minutes)) {
+        return ''
+    }
+
+    const total = Math.round(minutes)
+    if (!Number.isFinite(total) || total < 60) {
+        return `${minutes} ${labels.minute}`
+    }
+
+    const hours = Math.floor(total / 60)
+    const remainder = total - hours * 60
+
+    if (remainder === 0) {
+        return `${hours} ${labels.hour}`
+    }
+    return `${hours} ${labels.hour} ${remainder} ${labels.minute}`
+}


### PR DESCRIPTION
This is #4785 redone the way you asked: no user preference, the times are simply shown in a
human readable format.

> While I like the feature I think its a lot more complex than it need to be. I do not think we
> need the user preference. Just show the times in a human readable format.

The preference is gone entirely — `UserPreference.use_readable_time`, its migration, the
serializer entry, the Cosmetic settings checkbox and the regenerated client models are all out.
This pull request touches no Python at all. Six files, all under `vue3/`, and the formatting is
unconditional.

I have left the duration-field conversion alone. It is a much bigger change than this one, it
breaks the API for existing clients, and it sounded like something you may want to shape
yourself.

## What this does

Recipe and step durations are stored and displayed as a flat number of minutes, so a 72 hour
sourdough proof renders as `4320 min`, the step timer button shows a bare `4320`, and the recipe
card's time chip shows working + waiting summed with no unit at all.

A shared formatter in `vue3/src/utils/duration_utils.ts` converts minutes for display:

| Input | Output |
|---|---|
| 45 | `45 min` |
| 59 | `59 min` |
| 60 | `1 h` |
| 90 | `1 h 30 min` |
| 120 | `2 h` |
| 4320 | `72 h` |

Below an hour it stays minutes; from an hour up it renders `H h`, plus ` M min` when there is a
remainder. No day rollover — 4320 stays `72 h`, matching the table in #382. `Timer.vue` already
expresses "+3 Days" for the one case where a calendar day matters, and long proofs are spoken as
"72 hours", not "3 days".

Unit labels are passed in by the caller from translation keys, so no unit string is inlined in
the conversion logic. `min` already existed; `h` is new in `en.json`. English keys only, per
`docs/contribute/translations.md` — Weblate can take it from there.

Applied at the read-only duration displays: both `RecipeView` layouts, the `RecipeCard` time
chip, and the `StepView` timer button. Duration *inputs* keep plain minutes — entering durations
was never the problem, reading them is. It also removes two hardcoded `min` strings in
`RecipeView.vue` that bypassed i18n; they sat on the lines this rewrites.

## Notes

- Verified locally: `yarn build` and the full Python suite on a tree carrying this change.
- I left the surrounding reformatting alone rather than dragging unrelated churn into the diff —
  the files this touches do not currently satisfy the repo's prettier config either way. Happy to
  run it if you would prefer.

Closes #382.

